### PR TITLE
fix(release): set archive name_template to match binary name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,6 +23,7 @@ builds:
 
 archives:
   - format: binary
+    name_template: "{{ .Binary }}"
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
Without an explicit name_template, GoReleaser defaults to appending version
and platform info (e.g., `koto-linux-amd64_0.1.0_linux_amd64`). The install
script and tsuku recipe expect `koto-{os}-{arch}`.

Set `name_template: "{{ .Binary }}"` so release assets use the binary name
directly.

---

Found during #26 (v0.1.0 release validation). The release pipeline runs
correctly but produces incorrectly-named artifacts.

Ref #26