### PR TITLE
fix(release): update finalize job artifact names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,13 +67,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${GITHUB_REF_NAME}"
-          VERSION="${TAG#v}"
 
           EXPECTED_ARTIFACTS=(
-            "koto-linux-amd64_${VERSION}_linux_amd64"
-            "koto-linux-arm64_${VERSION}_linux_arm64"
-            "koto-darwin-amd64_${VERSION}_darwin_amd64"
-            "koto-darwin-arm64_${VERSION}_darwin_arm64"
+            "koto-linux-amd64"
+            "koto-linux-arm64"
+            "koto-darwin-amd64"
+            "koto-darwin-arm64"
           )
 
           echo "Verifying all ${#EXPECTED_ARTIFACTS[@]} artifacts are present..."


### PR DESCRIPTION
The name_template fix in .goreleaser.yaml (PR #30) produces `koto-{os}-{arch}`
but the finalize job's verification step still expected the old versioned names
like `koto-linux-amd64_0.1.0_linux_amd64`.

Update EXPECTED_ARTIFACTS to match the actual output names.

---

Second fix found during #26 (v0.1.0 release validation). The release job
succeeds but finalize fails on artifact verification.

Ref #26