### PR TITLE
docs: fix stale statuses on completed designs and plans

### DIFF
--- a/docs/designs/DESIGN-event-log-format.md
+++ b/docs/designs/DESIGN-event-log-format.md
@@ -1,5 +1,5 @@
 ---
-status: Planned
+status: Current
 problem: |
   koto's state model (from issue #45) uses a minimal JSONL format with no sequence
   numbers, no typed payloads, and no header line. This is intentionally incomplete —
@@ -27,7 +27,7 @@ rationale: |
 
 ## Status
 
-Planned
+Current
 
 ## Upstream Design Reference
 

--- a/docs/designs/DESIGN-migrate-koto-go-to-rust.md
+++ b/docs/designs/DESIGN-migrate-koto-go-to-rust.md
@@ -1,5 +1,5 @@
 ---
-status: Planned
+status: Current
 upstream: docs/designs/DESIGN-unified-koto-next.md
 problem: |
   koto is ~2,100 lines of Go across engine, controller, template, cache, and CLI
@@ -23,7 +23,7 @@ rationale: |
 
 ## Status
 
-Planned
+Current
 
 ## Upstream Design Reference
 

--- a/docs/plans/PLAN-event-log-format.md
+++ b/docs/plans/PLAN-event-log-format.md
@@ -1,6 +1,6 @@
 ---
 schema: plan/v1
-status: Draft
+status: Done
 execution_mode: single-pr
 upstream: docs/designs/DESIGN-event-log-format.md
 milestone: "Event Log Format"
@@ -11,7 +11,7 @@ issue_count: 4
 
 ## Status
 
-Draft
+Done
 
 ## Scope Summary
 

--- a/docs/plans/PLAN-migrate-koto-go-to-rust.md
+++ b/docs/plans/PLAN-migrate-koto-go-to-rust.md
@@ -1,6 +1,6 @@
 ---
 schema: plan/v1
-status: Draft
+status: Done
 execution_mode: single-pr
 upstream: docs/designs/DESIGN-migrate-koto-go-to-rust.md
 milestone: "Migrate koto from Go to Rust"
@@ -11,7 +11,7 @@ issue_count: 5
 
 ## Status
 
-Draft
+Done
 
 ## Scope Summary
 


### PR DESCRIPTION
Update status fields that were missed when PRs #50 and #52 merged:

- DESIGN-event-log-format.md: Planned -> Current
- PLAN-event-log-format.md: Draft -> Done
- DESIGN-migrate-koto-go-to-rust.md: Planned -> Current
- PLAN-migrate-koto-go-to-rust.md: Draft -> Done