### PR TITLE
ci: add tools/current to PATH for installed tool verification

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -119,6 +119,7 @@ jobs:
         run: |
           curl -fsSL https://get.tsuku.dev/now | bash
           echo "$HOME/.tsuku/bin" >> $GITHUB_PATH
+          echo "$HOME/.tsuku/tools/current" >> $GITHUB_PATH
 
       - name: Install koto from local recipe (PR)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
tsuku installs tool binaries via symlinks in \`\$TSUKU_HOME/tools/current/\`, not \`\$TSUKU_HOME/bin/\`. The install step only added \`~/.tsuku/bin\` to \`GITHUB_PATH\`, so \`koto version\` failed with "command not found" after the distributed install.

Add \`~/.tsuku/tools/current\` to \`GITHUB_PATH\` so installed tools are available in subsequent steps.

---

Fixes the post-merge CI failure introduced with #57.