### PR TITLE
docs(design): transition DESIGN-unified-koto-next to Current

### DIFF
--- a/docs/designs/current/DESIGN-unified-koto-next.md
+++ b/docs/designs/current/DESIGN-unified-koto-next.md
@@ -1,5 +1,5 @@
 ---
-status: Planned
+status: Current
 upstream: docs/prds/PRD-unified-koto-next.md
 problem: |
   koto's three core systems — CLI contract, state model, and workflow definition format —
@@ -30,7 +30,7 @@ rationale: |
 
 ## Status
 
-Planned
+Current
 
 ## Context and Problem Statement
 


### PR DESCRIPTION
Move DESIGN-unified-koto-next.md to docs/designs/current/ and update status from Planned to Current. All five implementation issues (#45–49) are closed and the unifying issue #43 was resolved by #59.

---

No issue — housekeeping transition.