### PR TITLE
ci: fix eval-plugins workflow file issue

### DIFF
--- a/.github/workflows/eval-plugins.yml
+++ b/.github/workflows/eval-plugins.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   prompt-eval:
     name: Prompt Regression Eval
-    if: ${{ github.event.pull_request.draft != true && secrets.ANTHROPIC_API_KEY != '' }}
+    if: ${{ github.event.pull_request.draft != true }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +26,10 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "ANTHROPIC_API_KEY not configured, skipping prompt evals"
+            exit 0
+          fi
           export PATH="$PWD/target/release:$PATH"
           bash plugins/koto-skills/eval.sh
 


### PR DESCRIPTION
Referencing `secrets.*` in a job-level `if:` condition is not supported by GitHub Actions. It causes the entire workflow to fail before any jobs run, with "This run likely failed because of a workflow file issue."

Move the `ANTHROPIC_API_KEY` check into the step body instead. If the secret is not configured, the step exits cleanly (`exit 0`) and the job reports success. When the key is present, evals run as before.

This has been failing on every push since March 18.