### PR TITLE
fix(ci): export PATH inline for koto version check

### DIFF
--- a/.github/workflows/check-template-freshness.yml
+++ b/.github/workflows/check-template-freshness.yml
@@ -49,6 +49,7 @@ jobs:
           fi
           curl -fsSL https://raw.githubusercontent.com/tsukumogami/koto/main/install.sh | bash -s -- $INSTALL_ARGS
           echo "$HOME/.koto/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.koto/bin:$PATH"
           koto version
 
       - name: Check Mermaid freshness


### PR DESCRIPTION
The install step in the reusable workflow appends to GITHUB_PATH, but
that only takes effect in the next step. The `koto version` verification
in the same step fails with "command not found". Add an inline
`export PATH` so the verification works within the same step.

---

## What changed

`.github/workflows/check-template-freshness.yml` -- added
`export PATH="$HOME/.koto/bin:$PATH"` before `koto version` in the
install step. The `GITHUB_PATH` append is kept for subsequent steps.

Discovered when shirabe's CI called the reusable workflow and the
freshness check step couldn't find koto despite successful installation.