### PR TITLE
fix(ci): skip .mermaid.md files in template freshness checks

### DIFF
--- a/.github/workflows/check-template-freshness.yml
+++ b/.github/workflows/check-template-freshness.yml
@@ -58,6 +58,7 @@ jobs:
           found=0
           while IFS= read -r template; do
             [ -z "$template" ] && continue
+            case "$template" in *.mermaid.md) continue ;; esac
             found=1
             stem="${template%.md}"
             output="${stem}.mermaid.md"
@@ -93,6 +94,7 @@ jobs:
 
           while IFS= read -r template; do
             [ -z "$template" ] && continue
+            case "$template" in *.mermaid.md) continue ;; esac
             stem=$(basename "${template%.md}")
             output="${html_dir}/${stem}.html"
 


### PR DESCRIPTION
The glob pattern `*.md` matches both source templates and generated
`.mermaid.md` files. The reusable workflow was trying to compile
`.mermaid.md` as a koto template, which fails because it has no YAML
frontmatter. Skip files ending in `.mermaid.md` in both the Mermaid
and HTML check loops.

---

Discovered when shirabe's CI called the reusable workflow with
`skills/*/koto-templates/*.md` and the glob matched both `work-on.md`
and `work-on.mermaid.md`.