### PR TITLE
fix(export): wrap mermaid file output in fenced code block

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -671,7 +671,16 @@ pub fn run(app: App) -> Result<()> {
                 };
 
                 let output_bytes = match args.format {
-                    ExportFormat::Mermaid => crate::export::to_mermaid(&compiled).into_bytes(),
+                    ExportFormat::Mermaid => {
+                        let raw = crate::export::to_mermaid(&compiled);
+                        if args.output.is_some() {
+                            // Wrap in fenced code block for GitHub rendering.
+                            format!("```mermaid\n{}```\n", raw).into_bytes()
+                        } else {
+                            // Raw mermaid text for stdout composability.
+                            raw.into_bytes()
+                        }
+                    }
                     ExportFormat::Html => crate::export::generate_html(&compiled),
                 };
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3088,9 +3088,14 @@ fn export_cli_writes_to_output_file() {
 
     let content = std::fs::read_to_string(&output_path).unwrap();
     assert!(
-        content.starts_with("stateDiagram-v2\n"),
-        "output file should contain mermaid diagram"
+        content.starts_with("```mermaid\n"),
+        "output file should start with mermaid fence"
     );
+    assert!(
+        content.ends_with("```\n"),
+        "output file should end with closing fence"
+    );
+    assert!(content.contains("stateDiagram-v2"));
     assert!(content.contains("[*] --> entry"));
 }
 


### PR DESCRIPTION
Mermaid files written via \`--output\` now start with \`\`\`\`mermaid and end
with \`\`\`\`, so GitHub renders them as diagrams. Stdout output stays raw
for composability. The \`--check\` comparison uses the fenced format since
it compares against the committed file.

---

## Behavior

| Mode | Format |
|------|--------|
| \`koto template export foo.md\` (stdout) | Raw mermaid text |
| \`koto template export foo.md --output foo.mermaid.md\` | Fenced in \`\`\`\`mermaid block |
| \`koto template export foo.md --output foo.mermaid.md --check\` | Compares against fenced format |