### PR TITLE
fix(export): use multi-line note syntax for mermaid gate annotations

### DIFF
--- a/src/export/mermaid.rs
+++ b/src/export/mermaid.rs
@@ -42,13 +42,12 @@ pub fn to_mermaid(template: &CompiledTemplate) -> String {
         lines.push(format!("    {} --> [*]", state_name));
     }
 
-    // Gate annotations.
+    // Gate annotations (multi-line note syntax avoids colon parsing issues).
     for (state_name, state) in &template.states {
         for gate_name in state.gates.keys() {
-            lines.push(format!(
-                "    note left of {} : gate: {}",
-                state_name, gate_name
-            ));
+            lines.push(format!("    note left of {}", state_name));
+            lines.push(format!("        gate: {}", gate_name));
+            lines.push("    end note".to_string());
         }
     }
 
@@ -286,7 +285,7 @@ mod tests {
         );
         let output = to_mermaid(&t);
         assert!(
-            output.contains("note left of start : gate: check-repo"),
+            output.contains("note left of start\n        gate: check-repo\n    end note"),
             "got:\n{}",
             output
         );
@@ -411,6 +410,6 @@ mod tests {
         assert!(output.contains("implement --> done"));
         assert!(output.contains("research --> evaluate"));
         assert!(output.contains("done --> [*]"));
-        assert!(output.contains("note left of explore : gate: check-repo"));
+        assert!(output.contains("note left of explore\n        gate: check-repo\n    end note"));
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2871,7 +2871,7 @@ fn export_multi_state_fixture_contains_expected_states_and_transitions() {
 
     // Gate annotation
     assert!(
-        mermaid.contains("note left of setup : gate: config_exists"),
+        mermaid.contains("note left of setup\n        gate: config_exists\n    end note"),
         "should have gate annotation for config_exists, got:\n{}",
         mermaid
     );
@@ -2891,7 +2891,7 @@ fn export_simple_gates_fixture_has_gate_and_when_labels() {
 
     // Gate note
     assert!(
-        mermaid.contains("note left of start : gate: check_file"),
+        mermaid.contains("note left of start\n        gate: check_file\n    end note"),
         "should have gate annotation for check_file, got:\n{}",
         mermaid
     );


### PR DESCRIPTION
The single-line \`note left of X : gate: Y\` syntax fails in GitHub's
Mermaid renderer because the colon in the note body is parsed as a state
descriptor separator. Switch to multi-line syntax which GitHub handles
correctly.

---

Before (fails to render):
\`\`\`
note left of analysis : gate: plan_artifact
\`\`\`

After (renders correctly):
\`\`\`
note left of analysis
    gate: plan_artifact
end note
\`\`\`