### PR TITLE
chore(release): version marketplace and plugin metadata during releases

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,11 +1,19 @@
 {
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "koto",
-  "owner": { "name": "tsukumogami" },
+  "description": "Workflow skills for koto -- the state machine engine for AI agent workflows",
+  "owner": {
+    "name": "tsukumogami"
+  },
   "plugins": [
     {
       "name": "koto-skills",
-      "source": "./plugins/koto-skills",
-      "description": "Workflow skills for koto"
+      "description": "Workflow skills for koto",
+      "version": "0.4.2-dev",
+      "author": {
+        "name": "tsukumogami"
+      },
+      "source": "./plugins/koto-skills"
     }
   ]
 }

--- a/.release/set-version.sh
+++ b/.release/set-version.sh
@@ -2,14 +2,25 @@
 # Set-version hook called by the reusable release workflow.
 # Receives the version without v prefix (e.g., 0.4.0 or 0.4.1-dev).
 #
-# Stamps the version in Cargo.toml. The runtime version is derived from
-# git tags by build.rs, but keeping Cargo.toml in sync makes the package
-# metadata correct for `cargo publish` and crate registries.
+# Stamps the version in Cargo.toml, marketplace.json, and plugin.json.
 
 set -euo pipefail
 
 VERSION="${1:?Usage: set-version.sh <version>}"
 
-sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+MARKETPLACE_JSON=".claude-plugin/marketplace.json"
+PLUGIN_JSON="plugins/koto-skills/.claude-plugin/plugin.json"
 
+# Stamp Cargo.toml
+sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
 echo "Stamped Cargo.toml to ${VERSION}"
+
+# Stamp marketplace.json plugins[0].version
+jq --arg v "$VERSION" '.plugins[0].version = $v' "$MARKETPLACE_JSON" > "$MARKETPLACE_JSON.tmp" \
+  && mv "$MARKETPLACE_JSON.tmp" "$MARKETPLACE_JSON"
+echo "Stamped $MARKETPLACE_JSON to ${VERSION}"
+
+# Stamp plugin.json .version
+jq --arg v "$VERSION" '.version = $v' "$PLUGIN_JSON" > "$PLUGIN_JSON.tmp" \
+  && mv "$PLUGIN_JSON.tmp" "$PLUGIN_JSON"
+echo "Stamped $PLUGIN_JSON to ${VERSION}"

--- a/plugins/koto-skills/.claude-plugin/plugin.json
+++ b/plugins/koto-skills/.claude-plugin/plugin.json
@@ -1,6 +1,11 @@
 {
   "name": "koto-skills",
-  "version": "0.1.0",
+  "version": "0.4.2-dev",
   "description": "Workflow skills for koto -- the state machine engine for AI agent workflows",
-  "skills": ["./skills/koto-author"]
+  "author": {
+    "name": "tsukumogami"
+  },
+  "skills": [
+    "./skills/koto-author"
+  ]
 }


### PR DESCRIPTION
Add version tracking to the koto marketplace, matching the pattern shirabe
uses. The set-version.sh release hook now stamps three files instead of one:
Cargo.toml (binary version), .claude-plugin/marketplace.json (marketplace
plugin version), and plugins/koto-skills/.claude-plugin/plugin.json (plugin
metadata version).

Also adds $schema, author, and version fields to marketplace.json that were
previously missing.

---

Previously, marketplace.json had no version field and set-version.sh only
stamped Cargo.toml. This meant plugin consumers couldn't tell which version
of koto-skills they had installed, and releases didn't update marketplace
metadata.