### PR TITLE
feat(engine): add is_set operator to when conditions for variable existence checks

### DIFF
--- a/plugins/koto-skills/skills/koto-author/references/template-format.md
+++ b/plugins/koto-skills/skills/koto-author/references/template-format.md
@@ -653,6 +653,37 @@ transitions:
 
 The compiler emits **W6** (non-fatal) when `"present"` appears against any other path (a flat agent-evidence key, a `gates.*` path, `context.*`, etc.) — it almost always means the author meant presence matching but used the wrong prefix.
 
+### The `is_set` matcher for template variables in `when` clauses
+
+A `when` clause can check whether a template variable was provided at init time using the `vars.<VARIABLE_NAME>: {is_set: true/false}` syntax. This lets templates branch based on whether an optional variable was set:
+
+```yaml
+variables:
+  SHARED_BRANCH:
+    description: "Shared branch name"
+    required: false
+    default: ""
+
+states:
+  start:
+    transitions:
+      - target: use_shared_branch
+        when:
+          vars.SHARED_BRANCH:
+            is_set: true
+      - target: create_branch
+        when:
+          vars.SHARED_BRANCH:
+            is_set: false
+```
+
+A variable counts as "set" when its value is a non-empty string. Variables that are absent or have an empty string default are "not set".
+
+The compiler enforces:
+- `vars.*` keys must use `{is_set: true}` or `{is_set: false}` as the value. Equality matchers (e.g., `vars.FOO: "bar"`) are rejected.
+- The variable name after `vars.` must be declared in the template's `variables` block.
+- `{is_set: true}` and `{is_set: false}` on the same field are disjoint (no mutual exclusivity conflict). Two identical `{is_set: true}` conditions on different transitions are flagged as conflicting.
+
 ### `deny_unknown_fields` narrowed to source templates
 
 `#[serde(deny_unknown_fields)]` applies only to `SourceState` (the YAML-frontmatter surface). Compiled template JSON files no longer reject unknown fields, so adding a new compiled-template field in a release doesn't brick state files created by earlier versions. Template authors still get strict rejection at compile time.

--- a/src/engine/advance.rs
+++ b/src/engine/advance.rs
@@ -9,8 +9,8 @@ use crate::engine::persistence::derive_overrides;
 use crate::engine::types::{now_iso8601, Event, EventPayload};
 use crate::gate::{GateOutcome, StructuredGateResult};
 use crate::template::types::{
-    is_present_matcher, ActionDecl, CompiledTemplate, TemplateState, EVIDENCE_NAMESPACE,
-    GATES_EVIDENCE_NAMESPACE,
+    is_is_set_matcher, is_present_matcher, ActionDecl, CompiledTemplate, TemplateState,
+    EVIDENCE_NAMESPACE, GATES_EVIDENCE_NAMESPACE, VARS_NAMESPACE,
 };
 
 /// Maximum number of transitions per invocation. Defense-in-depth against
@@ -189,6 +189,16 @@ where
     let mut transition_count: usize = 0;
     // Evidence is only used for the initial state; auto-advanced states start fresh.
     let mut current_evidence = evidence.clone();
+
+    // Extract template variables from the WorkflowInitialized event for vars.*
+    // when-clause evaluation (Issue #141).
+    let workflow_variables: std::collections::HashMap<String, String> = all_events
+        .iter()
+        .find_map(|e| match &e.payload {
+            EventPayload::WorkflowInitialized { variables, .. } => Some(variables.clone()),
+            _ => None,
+        })
+        .unwrap_or_default();
 
     // The starting state is NOT added to visited. The visited set tracks states
     // we've auto-advanced THROUGH during this invocation. The starting state was
@@ -451,7 +461,12 @@ where
             );
         }
         let evidence_value = serde_json::Value::Object(merged);
-        match resolve_transition(template_state, &evidence_value, gates_failed) {
+        match resolve_transition(
+            template_state,
+            &evidence_value,
+            gates_failed,
+            &workflow_variables,
+        ) {
             TransitionResolution::Resolved(target) => {
                 // Check for cycle before transitioning
                 if visited.contains(&target) {
@@ -566,6 +581,7 @@ pub fn resolve_transition(
     template_state: &TemplateState,
     evidence: &serde_json::Value,
     gate_failed: bool,
+    variables: &std::collections::HashMap<String, String>,
 ) -> TransitionResolution {
     if template_state.transitions.is_empty() {
         return TransitionResolution::NoTransitions;
@@ -576,6 +592,7 @@ pub fn resolve_transition(
     let mut has_conditional = false;
 
     let evidence_prefix = format!("{}.", EVIDENCE_NAMESPACE);
+    let vars_prefix = format!("{}.", VARS_NAMESPACE);
     for transition in &template_state.transitions {
         match &transition.when {
             Some(conditions) => {
@@ -592,6 +609,19 @@ pub fn resolve_transition(
                             && evidence
                                 .as_object()
                                 .is_some_and(|obj| obj.contains_key(inner));
+                    }
+                    // Issue #141: `vars.<name>: {is_set: bool}` checks whether
+                    // a template variable was provided at init time with a
+                    // non-empty value.
+                    if field.starts_with(&vars_prefix) {
+                        if let Some(expected_set) = is_is_set_matcher(expected) {
+                            let var_name = &field[vars_prefix.len()..];
+                            let is_set = variables
+                                .get(var_name)
+                                .map(|v| !v.is_empty())
+                                .unwrap_or(false);
+                            return is_set == expected_set;
+                        }
                     }
                     resolve_value(evidence, field) == Some(expected)
                 });
@@ -757,7 +787,7 @@ mod tests {
         let state = make_state(vec![unconditional("next")]);
         let evidence = as_evidence(BTreeMap::new());
         assert_eq!(
-            resolve_transition(&state, &evidence, false),
+            resolve_transition(&state, &evidence, false, &HashMap::new()),
             TransitionResolution::Resolved("next".to_string())
         );
     }
@@ -772,7 +802,7 @@ mod tests {
         m.insert("decision".to_string(), serde_json::json!("approve"));
         let evidence = as_evidence(m);
         assert_eq!(
-            resolve_transition(&state, &evidence, false),
+            resolve_transition(&state, &evidence, false, &HashMap::new()),
             TransitionResolution::Resolved("approved".to_string())
         );
     }
@@ -787,7 +817,7 @@ mod tests {
         m.insert("decision".to_string(), serde_json::json!("approve"));
         let evidence = as_evidence(m);
         assert_eq!(
-            resolve_transition(&state, &evidence, false),
+            resolve_transition(&state, &evidence, false, &HashMap::new()),
             TransitionResolution::Resolved("approved".to_string())
         );
     }
@@ -802,7 +832,7 @@ mod tests {
         m.insert("decision".to_string(), serde_json::json!("reject"));
         let evidence = as_evidence(m);
         assert_eq!(
-            resolve_transition(&state, &evidence, false),
+            resolve_transition(&state, &evidence, false, &HashMap::new()),
             TransitionResolution::Resolved("fallback".to_string())
         );
     }
@@ -817,7 +847,7 @@ mod tests {
         m.insert("x".to_string(), serde_json::json!(1));
         let evidence = as_evidence(m);
         assert_eq!(
-            resolve_transition(&state, &evidence, false),
+            resolve_transition(&state, &evidence, false, &HashMap::new()),
             TransitionResolution::Ambiguous(vec!["target_a".to_string(), "target_b".to_string()])
         );
     }
@@ -827,7 +857,7 @@ mod tests {
         let state = make_state(vec![]);
         let evidence = as_evidence(BTreeMap::new());
         assert_eq!(
-            resolve_transition(&state, &evidence, false),
+            resolve_transition(&state, &evidence, false, &HashMap::new()),
             TransitionResolution::NoTransitions
         );
     }
@@ -841,7 +871,7 @@ mod tests {
         // Empty evidence -- no match.
         let evidence = as_evidence(BTreeMap::new());
         assert_eq!(
-            resolve_transition(&state, &evidence, false),
+            resolve_transition(&state, &evidence, false, &HashMap::new()),
             TransitionResolution::NeedsEvidence
         );
     }
@@ -858,7 +888,7 @@ mod tests {
         m.insert("a".to_string(), serde_json::json!("x"));
         let evidence = as_evidence(m.clone());
         assert_eq!(
-            resolve_transition(&state, &evidence, false),
+            resolve_transition(&state, &evidence, false, &HashMap::new()),
             TransitionResolution::NeedsEvidence
         );
 
@@ -866,7 +896,7 @@ mod tests {
         m.insert("b".to_string(), serde_json::json!("y"));
         let evidence = as_evidence(m);
         assert_eq!(
-            resolve_transition(&state, &evidence, false),
+            resolve_transition(&state, &evidence, false, &HashMap::new()),
             TransitionResolution::Resolved("target".to_string())
         );
     }
@@ -888,13 +918,13 @@ mod tests {
 
         // gate_failed=false: unconditional fallback fires
         assert_eq!(
-            resolve_transition(&state, &evidence, false),
+            resolve_transition(&state, &evidence, false, &HashMap::new()),
             TransitionResolution::Resolved("fallback_state".to_string())
         );
 
         // gate_failed=true: unconditional fallback skipped, needs evidence
         assert_eq!(
-            resolve_transition(&state, &evidence, true),
+            resolve_transition(&state, &evidence, true, &HashMap::new()),
             TransitionResolution::NeedsEvidence
         );
 
@@ -903,7 +933,7 @@ mod tests {
         m.insert("status".to_string(), serde_json::json!("completed"));
         let with_evidence = as_evidence(m);
         assert_eq!(
-            resolve_transition(&state, &with_evidence, true),
+            resolve_transition(&state, &with_evidence, true, &HashMap::new()),
             TransitionResolution::Resolved("next_state".to_string())
         );
     }
@@ -933,7 +963,7 @@ mod tests {
             }
         });
         assert_eq!(
-            resolve_transition(&state, &evidence, false),
+            resolve_transition(&state, &evidence, false, &HashMap::new()),
             TransitionResolution::Resolved("success".to_string())
         );
 
@@ -947,7 +977,7 @@ mod tests {
             }
         });
         assert_eq!(
-            resolve_transition(&state, &evidence_fail, false),
+            resolve_transition(&state, &evidence_fail, false, &HashMap::new()),
             TransitionResolution::Resolved("failed".to_string())
         );
     }
@@ -963,14 +993,14 @@ mod tests {
         // Evidence without the "gates" key at all
         let evidence = serde_json::json!({ "mode": "issue_backed" });
         assert_eq!(
-            resolve_transition(&state, &evidence, false),
+            resolve_transition(&state, &evidence, false, &HashMap::new()),
             TransitionResolution::NeedsEvidence
         );
 
         // Evidence with "gates" but missing the "ci" sub-key
         let evidence_partial = serde_json::json!({ "gates": { "lint": { "exit_code": 0 } } });
         assert_eq!(
-            resolve_transition(&state, &evidence_partial, false),
+            resolve_transition(&state, &evidence_partial, false, &HashMap::new()),
             TransitionResolution::NeedsEvidence
         );
     }
@@ -995,7 +1025,7 @@ mod tests {
             "decision": "approve"
         });
         assert_eq!(
-            resolve_transition(&state, &evidence_both, false),
+            resolve_transition(&state, &evidence_both, false, &HashMap::new()),
             TransitionResolution::Resolved("approved".to_string())
         );
 
@@ -1004,14 +1034,14 @@ mod tests {
             "gates": { "ci": { "exit_code": 0, "error": "" } }
         });
         assert_eq!(
-            resolve_transition(&state, &evidence_gate_only, false),
+            resolve_transition(&state, &evidence_gate_only, false, &HashMap::new()),
             TransitionResolution::Resolved("pending".to_string())
         );
 
         // Only decision provided, gate output missing -- falls through to unconditional
         let evidence_decision_only = serde_json::json!({ "decision": "approve" });
         assert_eq!(
-            resolve_transition(&state, &evidence_decision_only, false),
+            resolve_transition(&state, &evidence_decision_only, false, &HashMap::new()),
             TransitionResolution::Resolved("pending".to_string())
         );
     }
@@ -1035,14 +1065,14 @@ mod tests {
         // retry_failed submitted (value irrelevant to the matcher) -> routes to retry.
         let evidence = serde_json::json!({ "retry_failed": ["task-1"] });
         assert_eq!(
-            resolve_transition(&state, &evidence, false),
+            resolve_transition(&state, &evidence, false, &HashMap::new()),
             TransitionResolution::Resolved("retry".to_string())
         );
 
         // retry_failed with a different payload shape still fires.
         let evidence_bool = serde_json::json!({ "retry_failed": true });
         assert_eq!(
-            resolve_transition(&state, &evidence_bool, false),
+            resolve_transition(&state, &evidence_bool, false, &HashMap::new()),
             TransitionResolution::Resolved("retry".to_string())
         );
     }
@@ -1062,7 +1092,7 @@ mod tests {
 
         let evidence = serde_json::json!({ "status": "pending" });
         assert_eq!(
-            resolve_transition(&state, &evidence, false),
+            resolve_transition(&state, &evidence, false, &HashMap::new()),
             TransitionResolution::NeedsEvidence
         );
     }
@@ -1077,7 +1107,7 @@ mod tests {
 
         let evidence = serde_json::json!({ "retry_failed": ["task-1"] });
         assert_eq!(
-            resolve_transition(&state, &evidence, false),
+            resolve_transition(&state, &evidence, false, &HashMap::new()),
             TransitionResolution::NeedsEvidence
         );
     }
@@ -1098,15 +1128,88 @@ mod tests {
         // Only the value-equality branch matches.
         let evidence = serde_json::json!({ "status": "done" });
         assert_eq!(
-            resolve_transition(&state, &evidence, false),
+            resolve_transition(&state, &evidence, false, &HashMap::new()),
             TransitionResolution::Resolved("complete".to_string())
         );
 
         // Value-equality miss still returns NeedsEvidence.
         let evidence_miss = serde_json::json!({ "status": "pending" });
         assert_eq!(
-            resolve_transition(&state, &evidence_miss, false),
+            resolve_transition(&state, &evidence_miss, false, &HashMap::new()),
             TransitionResolution::NeedsEvidence
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #141: vars.<name>: {is_set: bool} matcher
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn vars_is_set_true_matches_when_variable_present() {
+        let state = make_state(vec![
+            conditional(
+                "with_branch",
+                vec![("vars.SHARED_BRANCH", serde_json::json!({"is_set": true}))],
+            ),
+            conditional(
+                "without_branch",
+                vec![("vars.SHARED_BRANCH", serde_json::json!({"is_set": false}))],
+            ),
+        ]);
+
+        let evidence = as_evidence(BTreeMap::new());
+        let mut vars = HashMap::new();
+        vars.insert("SHARED_BRANCH".to_string(), "feature/foo".to_string());
+
+        assert_eq!(
+            resolve_transition(&state, &evidence, false, &vars),
+            TransitionResolution::Resolved("with_branch".to_string())
+        );
+    }
+
+    #[test]
+    fn vars_is_set_false_matches_when_variable_absent() {
+        let state = make_state(vec![
+            conditional(
+                "with_branch",
+                vec![("vars.SHARED_BRANCH", serde_json::json!({"is_set": true}))],
+            ),
+            conditional(
+                "without_branch",
+                vec![("vars.SHARED_BRANCH", serde_json::json!({"is_set": false}))],
+            ),
+        ]);
+
+        let evidence = as_evidence(BTreeMap::new());
+        let vars = HashMap::new(); // no variables
+
+        assert_eq!(
+            resolve_transition(&state, &evidence, false, &vars),
+            TransitionResolution::Resolved("without_branch".to_string())
+        );
+    }
+
+    #[test]
+    fn vars_is_set_false_matches_when_variable_empty() {
+        // An empty string counts as "not set" for is_set purposes.
+        let state = make_state(vec![
+            conditional(
+                "with_branch",
+                vec![("vars.SHARED_BRANCH", serde_json::json!({"is_set": true}))],
+            ),
+            conditional(
+                "without_branch",
+                vec![("vars.SHARED_BRANCH", serde_json::json!({"is_set": false}))],
+            ),
+        ]);
+
+        let evidence = as_evidence(BTreeMap::new());
+        let mut vars = HashMap::new();
+        vars.insert("SHARED_BRANCH".to_string(), String::new());
+
+        assert_eq!(
+            resolve_transition(&state, &evidence, false, &vars),
+            TransitionResolution::Resolved("without_branch".to_string())
         );
     }
 

--- a/src/engine/substitute.rs
+++ b/src/engine/substitute.rs
@@ -6,7 +6,8 @@ use crate::engine::types::{Event, EventPayload};
 use crate::template::types::VAR_REF_PATTERN;
 
 /// Allowlist regex for variable values: alphanumeric, dots, underscores, hyphens, forward slashes.
-const VALUE_PATTERN: &str = r"^[a-zA-Z0-9._/\-]+$";
+/// Empty strings are allowed for optional variables with no default (Issue #141).
+const VALUE_PATTERN: &str = r"^[a-zA-Z0-9._/\-]*$";
 
 /// Holds resolved variable bindings for substitution.
 #[derive(Debug)]
@@ -133,9 +134,9 @@ mod tests {
     }
 
     #[test]
-    fn validate_value_rejects_empty() {
-        let err = validate_value("KEY", "").unwrap_err();
-        assert_eq!(err.key, "KEY");
+    fn validate_value_accepts_empty() {
+        // Empty strings are valid for optional variables with no default (Issue #141).
+        validate_value("KEY", "").unwrap();
     }
 
     #[test]

--- a/src/template/types.rs
+++ b/src/template/types.rs
@@ -248,6 +248,22 @@ pub fn is_present_matcher(value: &serde_json::Value) -> bool {
     value.as_str() == Some(PRESENT_MATCHER_VALUE)
 }
 
+/// Namespace prefix for template variable existence checks in `when` clauses.
+/// Keys like `vars.MY_VAR` reference declared template variables.
+pub const VARS_NAMESPACE: &str = "vars";
+
+/// Check if a `when` value is an `{is_set: bool}` matcher.
+///
+/// Returns `Some(true)` for `{"is_set": true}`, `Some(false)` for
+/// `{"is_set": false}`, and `None` for any other shape.
+pub fn is_is_set_matcher(value: &serde_json::Value) -> Option<bool> {
+    let obj = value.as_object()?;
+    if obj.len() != 1 {
+        return None;
+    }
+    obj.get("is_set")?.as_bool()
+}
+
 /// The JSON value type of a gate output field.
 ///
 /// Used by [`gate_type_schema`] to describe the expected type of each field
@@ -1265,14 +1281,15 @@ impl CompiledTemplate {
             }
 
             // Separate gates.* keys (engine-injected gate output), evidence.<field>
-            // presence keys (Issue #11), and flat agent evidence keys. gates.* keys
-            // bypass the accepts block requirement and field-presence checks because
-            // they are populated automatically by the advance loop, not by agents.
+            // presence keys (Issue #11), vars.* keys (Issue #141), and flat agent
+            // evidence keys. gates.* and vars.* keys bypass the accepts block
+            // requirement because they are not agent-submitted evidence.
             // evidence.<field>: present checks only that the field appeared in any
             // submission since the last transition — it does not compare values,
             // so the field is not required to be declared in accepts.
             let gates_prefix = format!("{}.", GATES_EVIDENCE_NAMESPACE);
             let evidence_prefix = format!("{}.", EVIDENCE_NAMESPACE);
+            let vars_prefix = format!("{}.", VARS_NAMESPACE);
             let gate_fields: Vec<(&String, &serde_json::Value)> = when
                 .iter()
                 .filter(|(k, _)| k.starts_with(&gates_prefix))
@@ -1281,14 +1298,22 @@ impl CompiledTemplate {
                 .iter()
                 .filter(|(k, _)| k.starts_with(&evidence_prefix))
                 .collect();
+            let vars_fields: Vec<(&String, &serde_json::Value)> = when
+                .iter()
+                .filter(|(k, _)| k.starts_with(&vars_prefix))
+                .collect();
             let agent_fields: Vec<(&String, &serde_json::Value)> = when
                 .iter()
-                .filter(|(k, _)| !k.starts_with(&gates_prefix) && !k.starts_with(&evidence_prefix))
+                .filter(|(k, _)| {
+                    !k.starts_with(&gates_prefix)
+                        && !k.starts_with(&evidence_prefix)
+                        && !k.starts_with(&vars_prefix)
+                })
                 .collect();
 
             // Rule 5: when conditions that reference agent evidence require an accepts block.
-            // Pure gates.* and evidence.<field>: present conditions are allowed without
-            // an accepts block (presence checks do not reference declared schema).
+            // Pure gates.*, evidence.<field>: present, and vars.* conditions are allowed
+            // without an accepts block.
             if !agent_fields.is_empty() && !has_accepts {
                 return Err(format!(
                     "state {:?} transition to {:?}: when conditions require an accepts block on the state",
@@ -1312,6 +1337,35 @@ impl CompiledTemplate {
                         "state {:?} transition to {:?}: when value for evidence key {:?} must be {:?}; \
                          the evidence.<field> namespace only supports presence matching",
                         state_name, transition.target, field, PRESENT_MATCHER_VALUE
+                    ));
+                }
+            }
+
+            // Issue #141: validate vars.<name> entries use the {is_set: bool} matcher.
+            // The vars.* namespace only supports existence checking, not equality.
+            for (field, value) in &vars_fields {
+                let segments: Vec<&str> = field.splitn(3, '.').collect();
+                if segments.len() != 2 || segments[1].is_empty() {
+                    return Err(format!(
+                        "state {:?}: when clause key {:?} has invalid format; expected \"vars.<VARIABLE_NAME>\"",
+                        state_name, field.as_str()
+                    ));
+                }
+                let var_name = segments[1];
+                // The variable must be declared in the template's variables block.
+                if !self.variables.contains_key(var_name) {
+                    return Err(format!(
+                        "state {:?} transition to {:?}: when clause references undeclared variable {:?}; \
+                         add it to the template's variables block",
+                        state_name, transition.target, var_name
+                    ));
+                }
+                if is_is_set_matcher(value).is_none() {
+                    return Err(format!(
+                        "state {:?} transition to {:?}: when value for vars key {:?} must be \
+                         {{\"is_set\": true}} or {{\"is_set\": false}}; \
+                         the vars.* namespace only supports existence matching",
+                        state_name, transition.target, field
                     ));
                 }
             }
@@ -4339,6 +4393,255 @@ command: "./check.sh"
             warnings.is_empty(),
             "expected no W6 warnings for value-equality matchers; got: {:?}",
             warnings
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #141: is_set matcher and vars.* validation
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn is_is_set_matcher_true() {
+        assert_eq!(
+            is_is_set_matcher(&serde_json::json!({"is_set": true})),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn is_is_set_matcher_false() {
+        assert_eq!(
+            is_is_set_matcher(&serde_json::json!({"is_set": false})),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn is_is_set_matcher_rejects_non_object() {
+        assert_eq!(is_is_set_matcher(&serde_json::json!("is_set")), None);
+        assert_eq!(is_is_set_matcher(&serde_json::json!(true)), None);
+        assert_eq!(is_is_set_matcher(&serde_json::json!(42)), None);
+        assert_eq!(is_is_set_matcher(&serde_json::json!(null)), None);
+    }
+
+    #[test]
+    fn is_is_set_matcher_rejects_extra_keys() {
+        assert_eq!(
+            is_is_set_matcher(&serde_json::json!({"is_set": true, "extra": 1})),
+            None
+        );
+    }
+
+    #[test]
+    fn is_is_set_matcher_rejects_non_bool_value() {
+        assert_eq!(
+            is_is_set_matcher(&serde_json::json!({"is_set": "yes"})),
+            None
+        );
+    }
+
+    /// Helper: build a template with a declared optional variable and transitions
+    /// using vars.* when clauses.
+    fn template_with_var(var_name: &str) -> CompiledTemplate {
+        let mut t = minimal_template();
+        t.variables.insert(
+            var_name.to_string(),
+            VariableDecl {
+                description: String::new(),
+                required: false,
+                default: String::new(),
+            },
+        );
+        t
+    }
+
+    #[test]
+    fn vars_is_set_true_and_false_validate() {
+        let mut t = template_with_var("OPT_VAR");
+        // Add a middle state for the second branch.
+        t.states.insert(
+            "alt".to_string(),
+            TemplateState {
+                directive: "Alt path.".to_string(),
+                transitions: vec![Transition {
+                    target: "done".to_string(),
+                    when: None,
+                }],
+                terminal: false,
+                ..Default::default()
+            },
+        );
+        let state = t.states.get_mut("start").unwrap();
+        let mut when_set = BTreeMap::new();
+        when_set.insert(
+            "vars.OPT_VAR".to_string(),
+            serde_json::json!({"is_set": true}),
+        );
+        let mut when_unset = BTreeMap::new();
+        when_unset.insert(
+            "vars.OPT_VAR".to_string(),
+            serde_json::json!({"is_set": false}),
+        );
+        state.transitions = vec![
+            Transition {
+                target: "done".to_string(),
+                when: Some(when_set),
+            },
+            Transition {
+                target: "alt".to_string(),
+                when: Some(when_unset),
+            },
+        ];
+        assert!(
+            t.validate(true).is_ok(),
+            "vars.* with is_set true/false should validate"
+        );
+    }
+
+    #[test]
+    fn vars_equality_value_is_rejected() {
+        let mut t = template_with_var("FOO");
+        let state = t.states.get_mut("start").unwrap();
+        let mut when = BTreeMap::new();
+        when.insert("vars.FOO".to_string(), serde_json::json!("bar"));
+        state.transitions = vec![Transition {
+            target: "done".to_string(),
+            when: Some(when),
+        }];
+        let err = t.validate(true).unwrap_err();
+        assert!(
+            err.contains("only supports existence matching"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn vars_undeclared_variable_is_rejected() {
+        let mut t = minimal_template(); // no variables declared
+        let state = t.states.get_mut("start").unwrap();
+        let mut when = BTreeMap::new();
+        when.insert(
+            "vars.UNKNOWN".to_string(),
+            serde_json::json!({"is_set": true}),
+        );
+        state.transitions = vec![Transition {
+            target: "done".to_string(),
+            when: Some(when),
+        }];
+        let err = t.validate(true).unwrap_err();
+        assert!(
+            err.contains("undeclared variable") && err.contains("UNKNOWN"),
+            "got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn vars_is_set_mutual_exclusivity_disjoint() {
+        // {is_set: true} and {is_set: false} on the same field should NOT
+        // trigger a mutual exclusivity error (they are disjoint).
+        let mut t = template_with_var("OPT_VAR");
+        t.states.insert(
+            "alt".to_string(),
+            TemplateState {
+                directive: "Alt path.".to_string(),
+                transitions: vec![Transition {
+                    target: "done".to_string(),
+                    when: None,
+                }],
+                terminal: false,
+                ..Default::default()
+            },
+        );
+        let state = t.states.get_mut("start").unwrap();
+        let mut when_set = BTreeMap::new();
+        when_set.insert(
+            "vars.OPT_VAR".to_string(),
+            serde_json::json!({"is_set": true}),
+        );
+        let mut when_unset = BTreeMap::new();
+        when_unset.insert(
+            "vars.OPT_VAR".to_string(),
+            serde_json::json!({"is_set": false}),
+        );
+        state.transitions = vec![
+            Transition {
+                target: "done".to_string(),
+                when: Some(when_set),
+            },
+            Transition {
+                target: "alt".to_string(),
+                when: Some(when_unset),
+            },
+        ];
+        assert!(
+            t.validate(true).is_ok(),
+            "is_set true/false should be disjoint and not trigger mutual exclusivity error"
+        );
+    }
+
+    #[test]
+    fn vars_is_set_identical_flags_conflict() {
+        // Two transitions with {is_set: true} on the same field should trigger
+        // a mutual exclusivity error.
+        let mut t = template_with_var("OPT_VAR");
+        t.states.insert(
+            "alt".to_string(),
+            TemplateState {
+                directive: "Alt path.".to_string(),
+                transitions: vec![Transition {
+                    target: "done".to_string(),
+                    when: None,
+                }],
+                terminal: false,
+                ..Default::default()
+            },
+        );
+        let state = t.states.get_mut("start").unwrap();
+        let mut when_a = BTreeMap::new();
+        when_a.insert(
+            "vars.OPT_VAR".to_string(),
+            serde_json::json!({"is_set": true}),
+        );
+        let mut when_b = BTreeMap::new();
+        when_b.insert(
+            "vars.OPT_VAR".to_string(),
+            serde_json::json!({"is_set": true}),
+        );
+        state.transitions = vec![
+            Transition {
+                target: "done".to_string(),
+                when: Some(when_a),
+            },
+            Transition {
+                target: "alt".to_string(),
+                when: Some(when_b),
+            },
+        ];
+        let err = t.validate(true).unwrap_err();
+        assert!(err.contains("not mutually exclusive"), "got: {}", err);
+    }
+
+    #[test]
+    fn vars_does_not_require_accepts_block() {
+        // vars.* conditions should not require an accepts block (they are not
+        // agent-submitted evidence).
+        let mut t = template_with_var("OPT_VAR");
+        let state = t.states.get_mut("start").unwrap();
+        assert!(state.accepts.is_none(), "precondition: no accepts block");
+        let mut when = BTreeMap::new();
+        when.insert(
+            "vars.OPT_VAR".to_string(),
+            serde_json::json!({"is_set": true}),
+        );
+        state.transitions = vec![Transition {
+            target: "done".to_string(),
+            when: Some(when),
+        }];
+        assert!(
+            t.validate(true).is_ok(),
+            "vars.* should not require an accepts block"
         );
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7825,3 +7825,315 @@ fn overrides_record_with_data_at_file_missing_returns_clear_error() {
         msg
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #141: vars.* is_set when-clause operator
+// ---------------------------------------------------------------------------
+
+fn template_with_vars_is_set() -> String {
+    // with_var and without_var are terminal so the engine stops there,
+    // allowing us to check which branch was taken.
+    r#"---
+name: vars-is-set-workflow
+version: "1.0"
+initial_state: start
+variables:
+  OPT_VAR:
+    description: "Optional variable"
+    required: false
+    default: ""
+states:
+  start:
+    transitions:
+      - target: with_var
+        when:
+          vars.OPT_VAR:
+            is_set: true
+      - target: without_var
+        when:
+          vars.OPT_VAR:
+            is_set: false
+  with_var:
+    terminal: true
+  without_var:
+    terminal: true
+---
+
+## start
+
+Check if OPT_VAR is set.
+
+## with_var
+
+Variable is set. Done.
+
+## without_var
+
+Variable is not set. Done.
+"#
+    .to_string()
+}
+
+fn write_vars_is_set_template(dir: &Path) -> PathBuf {
+    let src = dir.join("vars-is-set.md");
+    std::fs::write(&src, template_with_vars_is_set()).unwrap();
+    src
+}
+
+#[test]
+fn vars_is_set_routes_to_set_branch_when_provided() {
+    let dir = TempDir::new().unwrap();
+    let src = write_vars_is_set_template(dir.path());
+
+    // Init WITH the variable
+    let init_output = koto_cmd(dir.path())
+        .args([
+            "init",
+            "test-set",
+            "--template",
+            src.to_str().unwrap(),
+            "--var",
+            "OPT_VAR=myvalue",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        init_output.status.success(),
+        "init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&init_output.stdout),
+        String::from_utf8_lossy(&init_output.stderr)
+    );
+
+    // Next should auto-advance to with_var (is_set: true branch) and stop (terminal)
+    let next_output = koto_cmd(dir.path())
+        .args(["next", "test-set"])
+        .output()
+        .unwrap();
+    assert!(
+        next_output.status.success(),
+        "next failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&next_output.stdout),
+        String::from_utf8_lossy(&next_output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&next_output.stdout).unwrap();
+    assert_eq!(
+        json["state"].as_str().unwrap(),
+        "with_var",
+        "should route to with_var when variable is set; got: {}",
+        json
+    );
+}
+
+#[test]
+fn vars_is_set_routes_to_unset_branch_when_not_provided() {
+    let dir = TempDir::new().unwrap();
+    let src = write_vars_is_set_template(dir.path());
+
+    // Init WITHOUT the variable (optional var with empty default)
+    let init_output = koto_cmd(dir.path())
+        .args(["init", "test-unset", "--template", src.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        init_output.status.success(),
+        "init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&init_output.stdout),
+        String::from_utf8_lossy(&init_output.stderr)
+    );
+
+    // Next should auto-advance to without_var (is_set: false branch) and stop (terminal)
+    let next_output = koto_cmd(dir.path())
+        .args(["next", "test-unset"])
+        .output()
+        .unwrap();
+    assert!(
+        next_output.status.success(),
+        "next failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&next_output.stdout),
+        String::from_utf8_lossy(&next_output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&next_output.stdout).unwrap();
+    assert_eq!(
+        json["state"].as_str().unwrap(),
+        "without_var",
+        "should route to without_var when variable is not set; got: {}",
+        json
+    );
+}
+
+#[test]
+fn compile_rejects_equality_matcher_on_vars_key() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("bad-vars.md");
+    std::fs::write(
+        &src,
+        r#"---
+name: bad-vars-workflow
+version: "1.0"
+initial_state: start
+variables:
+  FOO:
+    description: "A variable"
+    required: false
+states:
+  start:
+    transitions:
+      - target: done
+        when:
+          vars.FOO: "bar"
+  done:
+    terminal: true
+---
+
+## start
+
+Check FOO.
+
+## done
+
+Done.
+"#,
+    )
+    .unwrap();
+
+    let output = koto_cmd(dir.path())
+        .args(["template", "compile", src.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "compile should fail for equality matcher on vars.* key"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("only supports existence matching"),
+        "error should mention existence matching; got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn compile_rejects_undeclared_vars_reference() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("undeclared-var.md");
+    std::fs::write(
+        &src,
+        r#"---
+name: undeclared-vars-workflow
+version: "1.0"
+initial_state: start
+states:
+  start:
+    transitions:
+      - target: done
+        when:
+          vars.UNKNOWN:
+            is_set: true
+  done:
+    terminal: true
+---
+
+## start
+
+Check UNKNOWN.
+
+## done
+
+Done.
+"#,
+    )
+    .unwrap();
+
+    let output = koto_cmd(dir.path())
+        .args(["template", "compile", src.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "compile should fail for undeclared vars.* reference"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("undeclared variable") && stdout.contains("UNKNOWN"),
+        "error should mention undeclared variable UNKNOWN; got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn vars_is_set_mutual_exclusivity_allows_true_false_pair() {
+    let dir = TempDir::new().unwrap();
+    let src = write_vars_is_set_template(dir.path());
+
+    let output = koto_cmd(dir.path())
+        .args(["template", "compile", src.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "compile should accept is_set true/false as disjoint; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn vars_is_set_mutual_exclusivity_rejects_identical_conditions() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("conflicting-is-set.md");
+    std::fs::write(
+        &src,
+        r#"---
+name: conflicting-is-set-workflow
+version: "1.0"
+initial_state: start
+variables:
+  OPT_VAR:
+    description: "Optional variable"
+    required: false
+states:
+  start:
+    transitions:
+      - target: branch_a
+        when:
+          vars.OPT_VAR:
+            is_set: true
+      - target: branch_b
+        when:
+          vars.OPT_VAR:
+            is_set: true
+  branch_a:
+    terminal: true
+  branch_b:
+    terminal: true
+---
+
+## start
+
+Check OPT_VAR.
+
+## branch_a
+
+Branch A.
+
+## branch_b
+
+Branch B.
+"#,
+    )
+    .unwrap();
+
+    let output = koto_cmd(dir.path())
+        .args(["template", "compile", src.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "compile should fail for identical is_set conditions"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("not mutually exclusive"),
+        "error should mention mutual exclusivity; got: {}",
+        stdout
+    );
+}


### PR DESCRIPTION
Add `{is_set: true}` and `{is_set: false}` matchers for `vars.*` keys in `when` conditions, so templates can branch on whether an optional variable was provided at init time. The `vars.` namespace is compile-validated: matchers must use `{is_set: bool}` (not equality), and the variable name must be declared in the template frontmatter. The mutual exclusivity checker treats `{is_set: true}` and `{is_set: false}` on the same field as disjoint. The variable allowlist regex is relaxed from `+` to `*` so `required: false` variables that default to empty string pass validation.

`resolve_transition` in `src/engine/advance.rs` gains a `variables` parameter and evaluates `vars.*` keys against the `WorkflowInitialized` event's variable map.

Fixes #141

---

## Changes

- `src/template/types.rs`: `is_is_set_matcher()` helper, compile-time validation for `vars.*` keys, mutual exclusivity update
- `src/engine/advance.rs`: `vars.*` evaluation in `resolve_transition`, `variables` parameter threading
- `src/engine/substitute.rs`: allowlist regex `+` → `*` for empty optional variables
- `plugins/koto-skills/skills/koto-author/references/template-format.md`: document `is_set` syntax
- `tests/integration_test.rs`: 7 integration tests (routing with/without variable, compile rejections, mutual exclusivity)

## Example

```yaml
transitions:
  - target: done_plan_backed
    when:
      vars.SHARED_BRANCH: {is_set: true}
      finalization_status: ready_for_pr
  - target: pr_creation
    when:
      vars.SHARED_BRANCH: {is_set: false}
      finalization_status: ready_for_pr
```
