### PR TITLE
test(template): add regression tests for warning stderr routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "koto"
-version = "0.8.4-dev"
+version = "0.8.5-dev"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/test/functional/features/template-compile.feature
+++ b/test/functional/features/template-compile.feature
@@ -12,3 +12,21 @@ Feature: Template compilation
     When I run "koto template compile .koto/templates/bad.md"
     Then the exit code is not 0
     And the output contains "error"
+
+  Scenario: template export routes W3 warning to stderr not stdout
+    Given a clean koto environment
+    And the template "warn-triggers" exists
+    When I run "koto template export .koto/templates/warn-triggers.md"
+    Then the exit code is 0
+    And the output does not contain "warning:"
+    And the error output contains "warning:"
+    And the error output contains "W3:"
+
+  Scenario: template compile routes W3 warning to stderr not stdout
+    Given a clean koto environment
+    And the template "warn-triggers" exists
+    When I run "koto template compile .koto/templates/warn-triggers.md"
+    Then the exit code is 0
+    And the output does not contain "warning:"
+    And the error output contains "warning:"
+    And the error output contains "W3:"

--- a/test/functional/fixtures/templates/warn-triggers.md
+++ b/test/functional/fixtures/templates/warn-triggers.md
@@ -1,0 +1,37 @@
+---
+name: warn-triggers
+version: "1.0"
+description: Template with a terminal state name that triggers the W3 warning
+initial_state: start
+
+states:
+  start:
+    accepts:
+      status:
+        type: enum
+        values: [ok, fail]
+        required: true
+    transitions:
+      - target: done
+        when:
+          status: ok
+      - target: failed_result
+        when:
+          status: fail
+  done:
+    terminal: true
+  failed_result:
+    terminal: true
+---
+
+## start
+
+Choose an outcome.
+
+## done
+
+Completed successfully.
+
+## failed_result
+
+Terminal failure state. Name contains "fail" without `failure: true` — triggers W3.


### PR DESCRIPTION
Adds two functional scenarios to `template-compile.feature` that lock in the existing stderr routing behavior for `koto template export` and `koto template compile`. Both commands already used `eprintln!()` for W* warnings but had no test coverage for that property. A new fixture template `warn-triggers.md` triggers the W3 warning (a terminal state named `failed_result` without `failure: true`), providing a reliable test vector. The scenarios assert that stdout contains no warning lines while stderr carries the full warning message and code.

---

Fixes #149