### PR TITLE
feat(cli): wrap mermaid output in fence by default

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -991,13 +991,7 @@ pub fn run(app: App) -> Result<()> {
                 let output_bytes = match args.format {
                     ExportFormat::Mermaid => {
                         let raw = crate::export::to_mermaid(&compiled);
-                        if args.output.is_some() {
-                            // Wrap in fenced code block for GitHub rendering.
-                            format!("```mermaid\n{}```\n", raw).into_bytes()
-                        } else {
-                            // Raw mermaid text for stdout composability.
-                            raw.into_bytes()
-                        }
+                        format!("```mermaid\n{}```\n", raw).into_bytes()
                     }
                     ExportFormat::Html => crate::export::generate_html(&compiled),
                 };

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4151,10 +4151,15 @@ fn export_cli_outputs_mermaid_to_stdout() {
 
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(
-        stdout.starts_with("stateDiagram-v2\n"),
-        "CLI stdout should contain mermaid diagram, got:\n{}",
+        stdout.starts_with("```mermaid\n"),
+        "CLI stdout should be wrapped in mermaid fence, got:\n{}",
         stdout
     );
+    assert!(
+        stdout.ends_with("```\n"),
+        "CLI stdout should end with closing fence"
+    );
+    assert!(stdout.contains("stateDiagram-v2"));
     assert!(stdout.contains("[*] --> entry"));
     assert!(stdout.contains("done --> [*]"));
 }
@@ -5075,8 +5080,12 @@ fn export_30_state_template_latency_under_500ms() {
 
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(
-        stdout.starts_with("stateDiagram-v2\n"),
-        "output should be valid mermaid"
+        stdout.starts_with("```mermaid\n"),
+        "output should be wrapped in mermaid fence"
+    );
+    assert!(
+        stdout.ends_with("```\n"),
+        "output should end with closing fence"
     );
     assert!(
         stdout.contains("[*] --> s0"),


### PR DESCRIPTION
`src/cli/mod.rs` removes the `if args.output.is_some()` branch in the mermaid export path. Both stdout and `--output` now emit the same output: the raw mermaid diagram wrapped in a \`\`\`mermaid fence. Previously stdout received unwrapped mermaid, so `koto template export template.md > file.md` produced a file that didn't render in GitHub or VS Code preview. Two integration tests updated to expect the fence on stdout.

---

Fixes #148

## What This Fixes

Running `koto template export template.md 2>/dev/null > diagram.mermaid.md` now produces a file that renders immediately in any markdown viewer. The workaround of manually prepending/appending the fence is no longer needed.

## Test Plan

Covered by updated integration tests (`export_cli_outputs_mermaid_to_stdout`, `export_30_state_template_latency_under_500ms`). Both now assert stdout starts with ` ```mermaid` and ends with ` ``` `.