### PR TITLE
docs(config): scope a version-compatibility surface for koto

### DIFF
--- a/docs/briefs/BRIEF-config-version-compat.md
+++ b/docs/briefs/BRIEF-config-version-compat.md
@@ -4,11 +4,13 @@ status: Accepted
 problem: |
   Tools that embed koto -- importing its library, driving its CLI, or
   reading its session logs -- must stay compatible with it across
-  releases. koto exposes no stable surface that says what it is
-  compatible with: its config carries runtime tuning and nothing about
-  versioning. So a dependent tool hard-codes an assumption about koto's
-  behavior and breaks silently when koto moves, or pins to an exact
-  build and churns on every release.
+  releases. koto versions its on-disk contract internally (a schema
+  version gates the session-log format and STABILITY.md documents the
+  bump protocol), but none of that is queryable at the boundary: a
+  consumer cannot ask koto what contract version it honors and pin
+  against the answer. `koto version` reports the build, which moves
+  every release. So a dependent tool reverse-engineers compatibility or
+  over-pins, and breaks silently when koto moves.
 outcome: |
   A tool that embeds koto can ask koto what it is compatible with and
   get a stable answer it pins against. When koto changes in a way that
@@ -39,22 +41,26 @@ on it. They import its library, drive its CLI, and read the session
 event logs it writes, and they must keep working as koto evolves
 across releases.
 
-The problem is that koto gives them nothing stable to build that
-dependency on. There is no surface that answers "what is this koto
-compatible with?" -- its configuration carries session and
-request-store tuning, and says nothing about versioning or
-compatibility. A dependent tool is left with two bad options. It can
-hard-code an assumption about how koto behaves; that assumption rots
-silently the day koto changes, and the breakage shows up at runtime,
-far from its cause. Or it can pin to an exact koto build and refuse
-anything else; now it churns on every koto release, even the ones that
-changed nothing it depends on.
+koto is not silent about compatibility -- it just does not expose it
+where a consumer can use it. Internally a schema version
+(`CURRENT_SCHEMA_VERSION`) gates the session-log format, every log
+header carries the schema version it was written at, and `STABILITY.md`
+documents the protocol by which that version bumps and which surfaces
+are frozen. But all of that lives inside koto: the schema version is a
+constant and a number stamped in log files, and the contract is prose
+in a doc. There is no surface a dependent tool can read at the boundary
+that answers "what contract version is this koto?" -- `koto version`
+reports the build version, which moves on every release whether the
+contract changed or not.
 
-Either way the coupling is implicit and fragile. There is no point of
-record where koto states the contract it honors, so a consumer can
-neither depend on stability nor detect a real change deliberately. The
-compatibility relationship between koto and the tools built on it
-exists only as folklore in each consumer's code.
+So a dependent tool is left with two bad options. It can
+reverse-engineer compatibility -- parse a log header, read
+`STABILITY.md`, or guess from the release version -- and that inference
+rots silently the day koto changes, with the breakage showing up at
+runtime far from its cause. Or it can pin to an exact koto build and
+churn on every release, even the ones that changed nothing it depends
+on. The compatibility koto already tracks internally never reaches the
+consumers that need it as a value they can pin against.
 
 ## User Outcome
 
@@ -138,19 +144,23 @@ that the release deliberately set, not one inferred after the fact.
   version that moves independently of koto's release version, or a
   capability set -- and how it maps to the behavior consumers actually
   depend on. Deferred to the PRD and its design.
-- **Where the surface lives.** Whether consumers read it through a koto
-  CLI query, a field on the existing config surface, the session-log
-  header koto already writes, or a dedicated file -- and whether more
-  than one form is warranted for library versus CLI versus log-reading
-  consumers.
+- **Where the surface lives.** Whether consumers read it through the
+  existing `koto version` output (which already has a `--json` mode), a
+  new CLI query, a field on the config surface, the session-log header
+  koto already writes, or a dedicated file -- and whether more than one
+  form is warranted for library versus CLI versus log-reading consumers.
 - **Whether the statement is authored or derived.** Whether the
   compatibility value is set deliberately at release time or computed
   from koto's own version, and how it is kept honest across releases.
 
 ## References
 
+- `docs/STABILITY.md` -- koto's existing stability contract and the
+  `CURRENT_SCHEMA_VERSION` bump protocol this surface would publish.
+- `src/engine/types.rs` -- `CURRENT_SCHEMA_VERSION` and the
+  `schema_version` log-header field that already version the on-disk
+  contract internally.
+- `src/cli/mod.rs` -- the existing `koto version` command (with a
+  `--json` mode) that reports the build version today.
 - `docs/designs/current/DESIGN-config-and-cloud-sync.md` -- the design
-  for the configuration substrate this builds on.
-- `src/config/mod.rs`, `src/config/resolve.rs` -- the shipped config
-  types and the cascade resolution this surface would extend or sit
-  alongside.
+  for the configuration substrate this work sits alongside.

--- a/docs/briefs/BRIEF-config-version-compat.md
+++ b/docs/briefs/BRIEF-config-version-compat.md
@@ -1,0 +1,156 @@
+---
+schema: brief/v1
+status: Accepted
+problem: |
+  Tools that embed koto -- importing its library, driving its CLI, or
+  reading its session logs -- must stay compatible with it across
+  releases. koto exposes no stable surface that says what it is
+  compatible with: its config carries runtime tuning and nothing about
+  versioning. So a dependent tool hard-codes an assumption about koto's
+  behavior and breaks silently when koto moves, or pins to an exact
+  build and churns on every release.
+outcome: |
+  A tool that embeds koto can ask koto what it is compatible with and
+  get a stable answer it pins against. When koto changes in a way that
+  matters, the dependent tool sees the compatibility signal move and
+  reacts deliberately -- a clear failure at the boundary -- instead of
+  breaking in the dark at runtime.
+---
+
+# BRIEF: A version-compatibility surface for koto
+
+## Status
+
+Accepted
+
+Framing for the residual config work after the general-purpose
+configuration substrate already shipped (TOML `KotoConfig`, the
+defaults -> user -> project cascade, the `koto config` CLI, a
+project-key allowlist, and a programmatic API). This brief is not
+about building a config system; it frames one feature: a stable
+surface on which koto declares what it is compatible with, for the
+tools that embed it. The related project-config trust question is a
+separate feature and is held out of scope below.
+
+## Problem Statement
+
+koto is not a standalone end product; other tools in the toolkit build
+on it. They import its library, drive its CLI, and read the session
+event logs it writes, and they must keep working as koto evolves
+across releases.
+
+The problem is that koto gives them nothing stable to build that
+dependency on. There is no surface that answers "what is this koto
+compatible with?" -- its configuration carries session and
+request-store tuning, and says nothing about versioning or
+compatibility. A dependent tool is left with two bad options. It can
+hard-code an assumption about how koto behaves; that assumption rots
+silently the day koto changes, and the breakage shows up at runtime,
+far from its cause. Or it can pin to an exact koto build and refuse
+anything else; now it churns on every koto release, even the ones that
+changed nothing it depends on.
+
+Either way the coupling is implicit and fragile. There is no point of
+record where koto states the contract it honors, so a consumer can
+neither depend on stability nor detect a real change deliberately. The
+compatibility relationship between koto and the tools built on it
+exists only as folklore in each consumer's code.
+
+## User Outcome
+
+A tool that embeds koto can ask koto what it is compatible with and get
+a stable, reliable answer.
+
+At setup the tool reads koto's published compatibility surface and pins
+or validates against it -- it depends on a stated contract instead of
+guessing from koto's version number or its observed behavior. When koto
+later ships a change that matters to that contract, the surface moves,
+and the dependent tool sees it: it fails or warns at the boundary, on
+purpose, with a clear signal pointing at the compatibility mismatch.
+When koto ships a release that changed nothing the contract covers, the
+surface holds steady and the consumer keeps working without churn.
+
+The tool author stops reverse-engineering koto's compatibility from
+release notes and version strings, and starts relying on koto to state
+it. The coupling between koto and the tools built on it becomes
+explicit, legible, and safe to depend on.
+
+## User Journeys
+
+### A dependent tool pins to koto's compatibility
+
+A tool that embeds koto -- shirabe, for instance -- needs to know
+whether the koto it found on the system is one it supports. At setup it
+reads koto's published compatibility surface, learns the contract this
+koto honors, and pins or validates against it. It proceeds only against
+a koto it knows it is compatible with, rather than assuming and hoping.
+
+### A koto upgrade surfaces an incompatibility deliberately
+
+A developer upgrades koto under a tool that depends on it. The tool
+re-reads koto's compatibility surface, sees that the contract it pinned
+to has moved, and stops with a clear message about the mismatch --
+rather than running against an incompatible koto and failing somewhere
+deep and confusing later. The breakage is caught at the boundary, where
+it is cheap to understand.
+
+### A koto release states what it is compatible with
+
+The person cutting a koto release publishes the compatibility metadata
+as part of that release, so every koto build carries an accurate
+statement of the contract it honors. Consumers downstream read a value
+that the release deliberately set, not one inferred after the fact.
+
+## Scope Boundary
+
+**IN:**
+
+- A stable surface on which koto publishes its version-compatibility
+  metadata, in a form an embedding tool can read and pin against.
+- Defining what koto's compatibility statement means at that surface --
+  what a consumer is promised when the value holds and what it learns
+  when the value moves.
+- Building strictly on the configuration substrate and release process
+  that already exist.
+
+**OUT:**
+
+- **The project-config trust model.** Whether a checked-in
+  `.koto/config.toml` can silently change koto's behavior -- the key
+  allowlist versus an explicit per-directory trust opt-in -- is a
+  separate residual of the same config work. It shares no mechanism
+  with the compatibility surface (it governs config koto *accepts
+  inward*, not what koto *publishes outward*) and deserves its own
+  framing.
+- The consumer side of compatibility. koto publishes the surface; how a
+  dependent tool stores its pin and enforces it is that tool's own
+  work.
+- Rebuilding the configuration system. The TOML format, the cascade,
+  the `koto config` CLI, the allowlist, and the programmatic API
+  already exist and are not in scope to replace.
+- Cross-machine session storage and cloud sync as features. koto's
+  config serves them, but that functionality is separate work.
+
+## Open Questions
+
+- **What koto publishes.** Whether the compatibility statement is a
+  single version, a supported range, a separate contract or schema
+  version that moves independently of koto's release version, or a
+  capability set -- and how it maps to the behavior consumers actually
+  depend on. Deferred to the PRD and its design.
+- **Where the surface lives.** Whether consumers read it through a koto
+  CLI query, a field on the existing config surface, the session-log
+  header koto already writes, or a dedicated file -- and whether more
+  than one form is warranted for library versus CLI versus log-reading
+  consumers.
+- **Whether the statement is authored or derived.** Whether the
+  compatibility value is set deliberately at release time or computed
+  from koto's own version, and how it is kept honest across releases.
+
+## References
+
+- `docs/designs/current/DESIGN-config-and-cloud-sync.md` -- the design
+  for the configuration substrate this builds on.
+- `src/config/mod.rs`, `src/config/resolve.rs` -- the shipped config
+  types and the cascade resolution this surface would extend or sit
+  alongside.

--- a/docs/designs/DESIGN-config-version-compat.md
+++ b/docs/designs/DESIGN-config-version-compat.md
@@ -1,0 +1,191 @@
+---
+schema: design/v1
+status: Accepted
+upstream: docs/prds/PRD-config-version-compat.md
+problem: |
+  koto already tracks its contract compatibility internally
+  (`CURRENT_SCHEMA_VERSION` gates the session-log format, `STABILITY.md`
+  documents the bump protocol) but exposes nothing a dependent tool can
+  read at the boundary to pin against. `koto version` reports the build,
+  which moves every release. PRD-config-version-compat requires a
+  queryable, machine-readable, contract-versioned surface derived from
+  the version koto already maintains -- a single source of truth,
+  additive, and cheap to read.
+decision: |
+  Publish the existing `CURRENT_SCHEMA_VERSION` as a `schema_version`
+  field on the `BuildInfo` struct that `koto version --json` already
+  serializes, and document in `STABILITY.md` that this field is koto's
+  compatibility surface and what pinning to it promises. No new version
+  scheme, no new command, no new file: the compatibility koto already
+  tracks is surfaced through the version command that already exists.
+rationale: |
+  `CURRENT_SCHEMA_VERSION` is already the single source of truth for
+  contract compatibility and is already governed by the STABILITY.md
+  bump protocol, so surfacing it (rather than authoring a parallel
+  number) satisfies the single-source-of-truth requirement and adds no
+  maintenance. `koto version --json` is already the machine-readable
+  boundary surface, computed from static build info with no workflow,
+  storage, or network access -- so adding a field is additive (existing
+  json fields and the text output are untouched) and cheap to read,
+  meeting R7 and R8 directly.
+---
+
+# DESIGN: A version-compatibility surface for koto
+
+## Status
+
+Accepted
+
+Design for PRD-config-version-compat. Settles the deferred mechanism
+forks: what value koto publishes, where the surface lives, and how it
+stays a single source of truth.
+
+## Context and Problem Statement
+
+`koto version` (`src/cli/mod.rs`) prints build identity from
+`buildinfo::build_info()` -- a `BuildInfo { version, commit, built_at }`
+struct (`src/buildinfo.rs`). It has two modes: a human line
+(`koto <version> (<commit> <built_at>)`) and, with `--json`, the
+serde-serialized struct.
+
+Separately, `src/engine/types.rs` defines
+`pub const CURRENT_SCHEMA_VERSION: u32 = 1`, which gates the session-log
+format (readers reject logs written at a higher schema version), and
+`docs/STABILITY.md` documents the protocol that bumps it (patch: +0;
+minor: +0 or +1; major: +1 with a deprecation window) and the frozen
+surfaces it governs.
+
+The two never meet. A consumer can read the build version (which moves
+every release) or parse a log header (which requires a log to exist),
+but cannot ask koto for the contract version directly. The PRD requires
+exposing that contract version at the boundary, derived from what koto
+already tracks.
+
+## Decision Drivers
+
+- **R4 -- single source of truth.** The published value must not be a
+  parallel version that can drift from `CURRENT_SCHEMA_VERSION`.
+- **R7 -- additive.** Existing `koto version` consumers (text and json)
+  must not break.
+- **R8 -- cheap to read.** No workflow init, session storage, network,
+  or credentials when reading the value.
+- **R3 -- contract-versioned.** The value must move on contract change,
+  not on every build.
+- **Smallest surface that works.** The feature is a single value; it
+  should not add a command, a file, or a config key when an existing
+  surface serves.
+
+## Considered Options
+
+### Fork A -- What value is published
+
+- **A1 (chosen): publish `CURRENT_SCHEMA_VERSION` itself.** It is
+  already the contract-compatibility version, already governed by the
+  STABILITY.md bump protocol. Surfacing it is the single source of
+  truth by construction.
+- A2: author a new, separate "contract version" distinct from the schema
+  version. Rejected: a second number maintained by hand drifts from the
+  schema version (violates R4) and doubles the release discipline, for
+  no gain the schema version does not already provide.
+
+### Fork B -- Where the surface lives
+
+- **B1 (chosen): a `schema_version` field on `BuildInfo`, emitted by
+  `koto version --json`.** `koto version --json` is already the
+  machine-readable boundary surface, already computed from static build
+  info (R8), and adding a serde field is additive (R7). A consumer reads
+  `koto version --json` and takes `.schema_version`.
+- B2: a new `koto compat` subcommand. Rejected: a new top-level command
+  for one integer when `koto version --json` already exists and is where
+  a consumer looks for "what koto is this."
+- B3: a config-surface key. Rejected: compatibility is a property of the
+  build/contract, not user configuration; it does not belong in the
+  defaults/user/project cascade.
+- B4: the session-log header. Rejected: that already carries
+  `schema_version`, but it requires a log to exist and be parsed -- the
+  exact boundary problem this feature removes.
+
+### Fork C -- The human (text) output
+
+- **C (chosen): leave the text output unchanged; add the value to
+  `--json` only.** The text line is a stable surface some consumers
+  scrape; appending to it risks breaking strict parsers (R7). The
+  machine surface is `--json`, which is where a programmatic consumer
+  should read. (A later additive text line is possible but is not
+  required and is held out to keep R7 unambiguous.)
+
+## Decision Outcome
+
+1. Add `schema_version: u32` to `BuildInfo` (`src/buildinfo.rs`),
+   populated from `engine::types::CURRENT_SCHEMA_VERSION`.
+2. `koto version --json` emits it automatically (it serializes the whole
+   struct -- no handler change). The text output is untouched.
+3. Document in `STABILITY.md` that `koto version --json`'s
+   `schema_version` is koto's compatibility surface: a consumer pins
+   against it, it holds across releases that do not bump the schema
+   version, and it moves per the existing bump protocol.
+
+## Solution Architecture
+
+**`src/buildinfo.rs`.**
+```
+struct BuildInfo {
+    version: &'static str,     // unchanged: crate/build version
+    commit: &'static str,      // unchanged
+    built_at: &'static str,    // unchanged
+    schema_version: u32,       // NEW: = engine::types::CURRENT_SCHEMA_VERSION
+}
+```
+`build_info()` sets `schema_version` from the constant. The field is
+last so the existing json object gains a key without disturbing the
+others. (`BuildInfo` derives `Serialize`; the new field rides the same
+derive.)
+
+**`koto version --json` output** becomes
+`{"version":"...","commit":"...","built_at":"...","schema_version":1}`.
+A consumer reads `.schema_version` and pins against it. No code change
+in the `Command::Version` handler (`src/cli/mod.rs`) -- it already
+serializes the struct.
+
+**`docs/STABILITY.md`** gains a short "Compatibility version surface"
+section: names `koto version --json`'s `schema_version` as the value to
+pin against, states what holds while it is unchanged and what a bump
+signals, and cross-references the existing `CURRENT_SCHEMA_VERSION` bump
+protocol so the two are never separately maintained.
+
+## Implementation Approach
+
+Ordered, each step testable:
+
+1. **Add the field.** Add `schema_version: u32` to `BuildInfo`, populate
+   from `CURRENT_SCHEMA_VERSION` in `build_info()`. Unit test:
+   `build_info().schema_version == CURRENT_SCHEMA_VERSION`.
+2. **Lock the json contract.** Test that `koto version --json` parses as
+   JSON, still carries `version` / `commit` / `built_at`, and now carries
+   `schema_version` equal to `CURRENT_SCHEMA_VERSION`; and that the text
+   `koto version` output is unchanged.
+3. **Document the surface.** Add the `STABILITY.md` section and a
+   one-line pointer from wherever `CURRENT_SCHEMA_VERSION` is defined,
+   so a maintainer bumping the constant sees that it is published.
+
+## Security Considerations
+
+No new input, network, credential, or storage surface. The value is a
+compile-time constant emitted through a command that already runs with
+no side effects. It exposes only the schema version, which is already
+public in every session-log header and in `STABILITY.md`; surfacing it
+through `koto version --json` reveals nothing not already observable.
+
+## Consequences
+
+**Positive.** Single source of truth (the published value *is*
+`CURRENT_SCHEMA_VERSION`); additive (existing json fields and the text
+line are untouched); cheap (static, no IO); no new command, file, or
+config key. Consumers get a stable, machine-readable pin.
+
+**Negative / follow-ups.** The surface publishes only the schema/log
+contract version; if koto later wants to version its CLI or library
+contract independently of the log schema, that is a separate value and a
+later decision (the STABILITY.md "future surface" note already
+anticipates broader contracts). The text output deliberately does not
+carry the value, so a text-only consumer must move to `--json`.

--- a/docs/plans/PLAN-config-version-compat.md
+++ b/docs/plans/PLAN-config-version-compat.md
@@ -1,0 +1,105 @@
+---
+schema: plan/v1
+status: Draft
+execution_mode: single-pr
+upstream: docs/designs/DESIGN-config-version-compat.md
+milestone: "Version-compatibility surface for koto"
+issue_count: 3
+---
+
+# PLAN: A version-compatibility surface for koto
+
+## Status
+
+Draft
+
+Single-PR plan implementing DESIGN-config-version-compat. Three small,
+ordered steps on one branch, shipped as one pull request.
+
+## Scope Summary
+
+Surface koto's existing contract-compatibility version at the boundary:
+add `schema_version` (= `CURRENT_SCHEMA_VERSION`) to the `BuildInfo`
+struct so `koto version --json` emits it, and document in `STABILITY.md`
+that this field is koto's compatibility surface. No new version scheme,
+command, file, or config key; the text `koto version` output and the
+existing json fields are untouched.
+
+## Decomposition Strategy
+
+One PR, three steps: add the field (with a unit test), lock the
+`koto version --json` contract with a test, and document the surface.
+The first two are code; the third is docs and is independent. The PR is
+green only when `cargo test`, `cargo clippy -- -D warnings`, and
+`cargo fmt --check` all pass.
+
+## Implementation Issues
+
+Single-PR mode: no GitHub milestone or issues are created; the items
+below are the in-PR steps (internal IDs I1-I3) on one branch.
+
+### I1 -- Add the schema_version field to BuildInfo
+
+**Files:** `src/buildinfo.rs`.
+**Goal:** Add `schema_version: u32` to `BuildInfo` (last field, so the
+serialized json object gains a key without reordering the others), and
+populate it from `engine::types::CURRENT_SCHEMA_VERSION` in
+`build_info()`. `BuildInfo` already derives `Serialize`, so no
+serialization change is needed.
+**Acceptance:**
+- [ ] `build_info().schema_version == CURRENT_SCHEMA_VERSION` (unit test).
+- [ ] `cargo test` passes.
+
+### I2 -- Lock the `koto version --json` contract
+
+**Files:** a CLI/integration test (alongside the existing version-command
+tests).
+**Goal:** Assert that `koto version --json` output parses as JSON, still
+carries `version` / `commit` / `built_at`, and now carries
+`schema_version` equal to `CURRENT_SCHEMA_VERSION`; and that the plain
+`koto version` text output is unchanged (same `koto <version> (<commit>
+<built_at>)` shape, no new field).
+**Acceptance:**
+- [ ] Test confirms the four json fields (existing three plus
+      `schema_version`) and the unchanged text output.
+- [ ] `cargo test` passes.
+**Depends on:** I1.
+
+### I3 -- Document the compatibility surface
+
+**Files:** `docs/STABILITY.md`, and a one-line pointer where
+`CURRENT_SCHEMA_VERSION` is defined (`src/engine/types.rs`).
+**Goal:** Add a short "Compatibility version surface" section to
+`STABILITY.md`: name `koto version --json`'s `schema_version` as the
+value a consumer pins against, state what holds while it is unchanged
+and what a bump signals, and cross-reference the existing
+`CURRENT_SCHEMA_VERSION` bump protocol so the value and its publication
+are never maintained separately. Add a comment near the constant noting
+that it is published through `koto version --json`.
+**Acceptance:**
+- [ ] `STABILITY.md` documents the surface and what pinning to it
+      promises; the constant carries a pointer to its publication.
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    I1[I1: Add schema_version field]
+    I2[I2: Lock --json contract test]
+    I3[I3: Document the surface]
+
+    I1 --> I2
+```
+
+I3 is independent and may land at any point.
+
+## Implementation Sequence
+
+1. **I1** (add the field) -- foundation.
+2. **I2** (lock the json contract) -- builds on I1.
+3. **I3** (docs) -- independent; land alongside.
+
+Definition of done: all acceptance boxes checked; `cargo test`,
+`cargo clippy -- -D warnings`, and `cargo fmt --check` clean; and
+`koto version --json` shows `schema_version` while `koto version` text
+output is unchanged.

--- a/docs/prds/PRD-config-version-compat.md
+++ b/docs/prds/PRD-config-version-compat.md
@@ -1,0 +1,179 @@
+---
+schema: prd/v1
+status: Accepted
+problem: |
+  koto already versions its on-disk contract internally --
+  `CURRENT_SCHEMA_VERSION` gates the session-log format, log headers
+  carry `schema_version`, and `STABILITY.md` documents the bump protocol
+  -- but none of it is queryable at the boundary. `koto version` reports
+  the build, which moves every release regardless of the contract. So a
+  tool that embeds koto reverse-engineers compatibility (parsing a log
+  header, reading STABILITY.md, or guessing from the release version) or
+  over-pins, and breaks silently when koto changes.
+goals: |
+  Publish koto's contract-compatibility version on a queryable,
+  machine-readable surface a dependent tool can read and pin against,
+  derived from the compatibility koto already tracks internally and
+  documented so a consumer knows what holds while it is unchanged and
+  what it learns when it moves.
+---
+
+# PRD: A version-compatibility surface for koto
+
+## Status
+
+Accepted
+
+Requirements for exposing koto's contract-compatibility version to the
+tools that embed it, derived from the accepted
+`docs/briefs/BRIEF-config-version-compat.md`. This builds on the
+compatibility koto already tracks (`CURRENT_SCHEMA_VERSION`,
+`schema_version` log headers, `STABILITY.md`); it does not introduce a
+parallel versioning scheme. Mechanism choices (the exact surface, the
+value's shape, how it stays honest) are left to the design.
+
+## Problem Statement
+
+koto is a dependency for other tools in the toolkit: they import its
+library, drive its CLI, and read the session event logs it writes, and
+they must keep working as koto evolves.
+
+koto is not silent about compatibility. A schema version
+(`CURRENT_SCHEMA_VERSION`) gates the session-log format, every log
+header records the schema version it was written at, and `STABILITY.md`
+documents the protocol by which that version bumps and which surfaces
+are frozen. The problem is that this information is not reachable where
+a consumer needs it. The schema version is an internal constant and a
+number stamped inside log files; the contract is prose in a document.
+There is no surface a dependent tool can read at the boundary -- cheaply,
+programmatically -- that answers "what contract version is this koto?"
+`koto version` reports the build version, which moves on every release
+whether the contract changed or not, so it cannot serve as the pin.
+
+The result: a consumer reverse-engineers koto's compatibility (parsing a
+log header, reading the stability doc, or inferring from the release
+number) and that inference rots silently the day koto changes, with the
+break surfacing at runtime far from its cause; or it over-pins to an
+exact build and churns on every release. The compatibility koto already
+tracks internally never reaches the consumers that need it as a value
+they can pin against.
+
+## Goals
+
+- A dependent tool can read koto's contract-compatibility version from a
+  stable, machine-readable surface at the boundary, without parsing a
+  session log or running a workflow.
+- That version reflects koto's *contract*, not its build: it holds
+  steady across releases that change nothing a consumer depends on, and
+  moves when the contract changes -- so a real incompatibility is
+  detectable deliberately.
+- The published version is derived from the compatibility koto already
+  tracks, so there is a single source of truth, not a parallel scheme
+  that can drift.
+- A consumer knows what the version promises: the contract is documented
+  alongside the value.
+
+## User Stories
+
+Use-case form (this is a developer-tooling integration feature):
+
+- As an author of a tool that embeds koto, I read koto's published
+  compatibility version at setup and pin or validate against it, so I
+  depend on a stated contract instead of guessing from the release
+  number or parsing a log header.
+- As that author, when koto ships a release that changed nothing my
+  contract covers, the compatibility version holds steady and my tool
+  keeps working without a churned pin.
+- As that author, when koto changes its contract incompatibly, the
+  compatibility version moves and my tool detects the mismatch at the
+  boundary with a clear signal, instead of failing deep at runtime.
+- As a koto maintainer, the published compatibility version stays
+  consistent with the schema version and stability protocol koto already
+  maintains, so I am not keeping two version schemes honest by hand.
+
+## Requirements
+
+Functional:
+
+- **R1 -- Queryable at the boundary.** koto SHALL expose its
+  contract-compatibility version on a surface a dependent tool can read
+  programmatically without parsing a session-log header or executing a
+  workflow.
+- **R2 -- Machine-readable and stable.** The surface SHALL present the
+  version in a stable, parseable form a consumer can read and compare
+  across koto builds.
+- **R3 -- Contract-versioned, not build-versioned.** The compatibility
+  version SHALL be distinct from koto's build/release version: it SHALL
+  hold steady across releases that do not change the consumer contract
+  and SHALL move when the contract changes, per koto's documented
+  bump protocol.
+- **R4 -- Single source of truth.** The published version SHALL be
+  derived from or identical to the compatibility koto already tracks
+  (`CURRENT_SCHEMA_VERSION` and the `STABILITY.md` protocol), not a
+  separate, independently-maintained version that can drift from it.
+- **R5 -- Documented meaning.** koto SHALL document what the
+  compatibility version promises -- what a consumer can rely on while it
+  is unchanged, and what it learns when it moves -- extending the
+  existing stability contract rather than restating it.
+- **R6 -- Present on every build.** Every koto build SHALL carry an
+  accurate compatibility version on the surface.
+
+Non-functional:
+
+- **R7 -- Additive and compatible.** Exposing the surface SHALL NOT
+  break existing consumers of `koto version` output or change the
+  session-log format; existing fields and behavior SHALL be preserved.
+- **R8 -- Cheap to read.** Reading the compatibility version SHALL not
+  require koto to initialize a workflow, touch session storage, or
+  perform network or credential operations.
+
+## Acceptance Criteria
+
+- [ ] A consumer reads koto's compatibility version from a documented,
+      machine-readable surface without parsing a log or running a
+      workflow.
+- [ ] The compatibility version is distinct from the build version and
+      changes only according to the documented contract-bump rules.
+- [ ] The published value is consistent with `CURRENT_SCHEMA_VERSION`
+      and the `STABILITY.md` protocol (a single source of truth, not a
+      second scheme).
+- [ ] `STABILITY.md` (or the documented contract) states what the
+      compatibility version promises and when it moves.
+- [ ] Existing `koto version` output and the session-log format are
+      unchanged for current consumers (additive only).
+- [ ] The existing koto test suite passes; stability/forward-compat
+      checks are unbroken.
+
+## Out of Scope
+
+- **The project-config trust model.** Whether a checked-in
+  `.koto/config.toml` can silently change koto's behavior (the key
+  allowlist versus a per-directory opt-in) is the sibling residual of
+  the same config work and is scoped separately.
+- **The consumer side.** How a dependent tool stores its pin, compares
+  versions, and enforces the result is that tool's own work.
+- **Rebuilding the config system or the version command.** The config
+  substrate and `koto version` already exist; this extends them.
+- **Broadening the contract.** Defining new frozen surfaces beyond what
+  `STABILITY.md` already governs is not in scope unless the design finds
+  it unavoidable.
+- **Cross-machine storage and cloud sync as features.**
+
+## Decisions and Trade-offs
+
+- **Build on `CURRENT_SCHEMA_VERSION`, do not invent a parallel
+  version.** koto already maintains a schema version and a bump protocol;
+  a second, independently-authored compatibility number would drift from
+  it and double the maintenance. The published version is the existing
+  one, surfaced -- the design decides whether it is exactly
+  `CURRENT_SCHEMA_VERSION` or a contract version computed from it.
+- **Contract version, not build version.** The build version
+  (`koto version`) moves every release and cannot serve as a pin; the
+  value of this feature is precisely a version that moves only on
+  contract change. R3 fixes that property; the design picks how it maps
+  to the bump protocol.
+- **Additive surface.** Exposing the version through the existing
+  `koto version` output (which already has a `--json` mode) keeps the
+  change additive and avoids a new top-level surface; the design
+  confirms the exact location, but R7 fixes that current consumers must
+  not break.


### PR DESCRIPTION
Scope the version-compatibility residual of koto's config work, end to
end: a planning chain (BRIEF -> PRD -> DESIGN -> PLAN) for surfacing
koto's contract-compatibility version so the tools that embed it can pin
against it. Implementation is intentionally not part of this PR.

---

## Two findings from scoping (both shaped the result)

1. **The config residual was two features, not one.** Scoping surfaced
   an *outward* compatibility-publication surface and an *inward*
   project-config trust model bundled under one roadmap line. They share
   no mechanism, so this chain scopes only the **version-compatibility
   surface**; the **project-config trust model** (the key allowlist vs a
   per-directory opt-in) is held out as a sibling for its own scope run.

2. **The feature is small -- koto already tracks the version.** Grounding
   against the code corrected the premise: koto already versions its
   contract (`CURRENT_SCHEMA_VERSION` gates the session-log format, log
   headers carry `schema_version`, `STABILITY.md` documents the bump
   protocol). The only gap is that none of it is queryable at the
   boundary (`koto version` reports the build, not the contract).

## What the chain settled

The design lands small and additive: publish the existing
`CURRENT_SCHEMA_VERSION` as a `schema_version` field on the `BuildInfo`
struct that `koto version --json` already serializes, and document in
`STABILITY.md` that this field is the value to pin against. No new
version scheme, command, file, or config key; the text `koto version`
output and the existing json fields are untouched (single source of
truth, cheap to read).

## Artifacts (this PR)

- `docs/briefs/BRIEF-config-version-compat.md` (Accepted)
- `docs/prds/PRD-config-version-compat.md` (Accepted)
- `docs/designs/DESIGN-config-version-compat.md` (Accepted)
- `docs/plans/PLAN-config-version-compat.md` (Draft) -- a 3-step
  single-PR plan

## Status

Planning complete. Implementation (3 small steps: add the field, lock
the `--json` contract with a test, document the surface) is a separate
piece of work, not in this PR.
