### PR TITLE
ci: validate docs with shirabe's reusable engine workflow

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -1,0 +1,15 @@
+name: Validate doc formats
+
+# Calls shirabe's reusable per-file document validator so the engine is the
+# authority for artifact-doc format checks (frontmatter, sections, issues-table
+# rows, etc.) on the docs changed in a PR. Docs that carry a `schema:` field are
+# validated; docs predating that convention are skipped with a notice.
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+
+jobs:
+  validate:
+    uses: tsukumogami/shirabe/.github/workflows/validate-docs.yml@v0.11.0


### PR DESCRIPTION
Adopt shirabe's reusable per-file document validator so the engine validates artifact-doc formats (frontmatter, sections, issues-table rows) on doc PRs — matching shirabe, tsuku, and the other tsukumogami repos.

---

## Why

This repo had no validation of its artifact docs; doc PRs went ungated. Calling the shared engine workflow makes the engine the single authority for doc format checks here too, without maintaining any local check scripts.

## Scope and coverage

- Per-file and **changed-files only**, so the existing corpus is not gated — no red-wall on legacy docs.
- Docs carrying a `schema:` field are validated; docs predating that convention are skipped with a notice. Most of this repo's docs predate the schema convention, so this validates the newer schema-bearing docs and any new ones going forward. Migrating the legacy corpus to the schema format (for full coverage) is a separate effort.
- The whole-tree `lifecycle` check is intentionally **not** adopted here yet; it needs a corpus-posture pass first.