### PR TITLE
ci: adopt shirabe PR-body conformance gate

### DIFF
--- a/.github/workflows/validate-pr-body.yml
+++ b/.github/workflows/validate-pr-body.yml
@@ -1,0 +1,37 @@
+name: Validate PR body
+
+# Calls shirabe's reusable PR-body conformance gate. The reusable workflow
+# builds the shirabe binary at the referenced ref and runs
+# `shirabe validate --pr-body` against this PR's title and body, checking the
+# mechanical, path-independent parts of the two-part squash-merge convention
+# (Conventional Commits title; one `---` separator with a non-empty Part 1; no
+# AI-attribution footer). The rule is single-sourced in shirabe's
+# references/pr-body-conformance.md.
+#
+# The gate is path-independent by design: no `paths:` filter, so a malformed PR
+# body is caught regardless of which files the diff touches and regardless of
+# which code path opened the PR (a manual `gh pr create`, a dispatched worker,
+# or a skill).
+#
+# Pinned to @main to match this repo's other shirabe reusable-workflow
+# adoption (validate-docs.yml), so the gate always runs the current engine
+# without per-release pin bumps.
+#
+# `types:` mirrors shirabe's own self-caller: `edited` re-checks a body edited
+# after the PR opens (e.g. fixed in the GitHub UI) and `ready_for_review`
+# re-runs at the draft-to-ready flip.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+# Granted on the caller so the called reusable workflow's `permissions` block
+# (contents: read + pull-requests: read) is a subset of what this caller has.
+# A reusable workflow cannot request a permission the caller lacks.
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  pr-body:
+    uses: tsukumogami/shirabe/.github/workflows/pr-body.yml@main


### PR DESCRIPTION
Adopt shirabe's reusable PR-body conformance gate by adding `.github/workflows/validate-pr-body.yml`. On every pull request it calls `tsukumogami/shirabe/.github/workflows/pr-body.yml`, which builds the shirabe binary and runs `shirabe validate --pr-body` against the PR's title and body. This checks the mechanical parts of the two-part squash-merge convention: a Conventional Commits title, exactly one top-level `---` separator with a non-empty Part 1, and no AI-attribution footer.

Until now only shirabe self-hosted this gate, so a malformed PR in this repo went unchecked. The gate is path-independent — no `paths:` filter — so it fires regardless of which files a PR touches or which code path opened it.

---

## What this accomplishes

The PR-body gate now runs on every koto PR, catching malformed bodies at open time instead of after merge. This PR dogfoods the gate: its own title and body pass the checks it deploys.

## Ref pinning

Pinned to `@main`, matching this repo's existing `validate-docs.yml` shirabe adoption (release workflows pin `@v0.2.0`; the doc/PR-body validators track `@main`). The `types:` trigger mirrors shirabe's own self-caller so a body edited after open, or a draft flipped to ready, is re-checked.

## Testing

- `validate-pr-body.yml` is a thin caller of the reusable workflow; no new logic in this repo.
- CI on this PR exercises the gate against this body.
