### PR TITLE
fix(ci): clear failing cargo-audit advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,27 @@
+# cargo-audit configuration
+#
+# See https://github.com/rustsec/rustsec/blob/main/cargo-audit/audit.toml.example
+
+[advisories]
+# Scoped, temporary ignores. Remove each entry once the transitive constraint
+# allows a patched release.
+#
+# RUSTSEC-2026-0194 / RUSTSEC-2026-0195: quick-xml DoS advisories (quadratic
+# attribute-duplicate check; unbounded namespace-declaration allocation in
+# NsReader). Both are fixed in quick-xml >= 0.41.0, but quick-xml reaches us
+# only transitively through rust-s3 -> aws-creds, which pin `quick-xml = "0.38"`.
+# The latest published rust-s3 (0.37.2) still carries that pin, so no reachable
+# release lets us upgrade quick-xml without an upstream rust-s3 change.
+#
+# Reachability: quick-xml here only parses XML that rust-s3 receives from the
+# configured S3-compatible endpoint (error and list responses). Triggering
+# either DoS requires the object-storage endpoint to return crafted XML, i.e. a
+# trusted, operator-configured backend rather than arbitrary attacker input, so
+# the practical exposure for koto is low.
+#
+# TODO: drop these once rust-s3/aws-creds ship a release that permits
+# quick-xml >= 0.41.0, then `cargo update -p quick-xml`.
+ignore = [
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "koto"
-version = "0.10.0"
+version = "0.10.1-dev"
 dependencies = [
  "anyhow",
  "assert_cmd",


### PR DESCRIPTION
Bump `crossbeam-epoch` 0.9.18 -> 0.9.20 in `Cargo.lock` and add `.cargo/audit.toml` with a scoped, commented ignore for RUSTSEC-2026-0194 and RUSTSEC-2026-0195.

The `Audit` job runs `cargo audit`, which fetches the RustSec advisory DB live, so newly published advisories fail the job repo-wide independent of any code change. Three vulnerabilities currently match the locked tree. `crossbeam-epoch` has a patched release within its existing `0.9.x` constraint, so it is a clean lockfile bump. `quick-xml` (0.38.4) is fixed only in 0.41.0, but it is transitive through `rust-s3 -> aws-creds`, both pinning `quick-xml = "0.38"`, and no published `rust-s3` release relaxes that pin, so the two `quick-xml` advisories are suppressed with a scoped ignore carrying a removal TODO. The remaining `paste`/`anyhow`/`lru` findings are warnings that `cargo audit` does not fail on.

---

## Root Cause

`cargo audit` resolves advisories against the live RustSec DB, not against a pinned snapshot. `main` last ran `validate` on 2026-06-13; advisories published after that date turn the job red on every branch without any dependency change. This is a time-based, repo-wide failure, not a regression from a specific PR.

| Advisory | Crate | Resolution |
|----------|-------|------------|
| RUSTSEC-2026-0204 | crossbeam-epoch < 0.9.20 | Bump to 0.9.20 (clean, within `0.9.x`) |
| RUSTSEC-2026-0194 | quick-xml < 0.41.0 | Scoped ignore |
| RUSTSEC-2026-0195 | quick-xml < 0.41.0 | Scoped ignore |

## Why quick-xml is ignored rather than upgraded

`quick-xml` reaches the tree only through `rust-s3 -> aws-creds`, both of which pin `quick-xml = "0.38"`. The fix ships in `quick-xml >= 0.41.0`, and the latest published `rust-s3` (0.37.2) still carries the `0.38` pin, so the patched version is unreachable without an upstream `rust-s3` change. `cargo update -p quick-xml --precise 0.41.0` fails version selection for this reason. The ignore is scoped to the two IDs, commented with the constraint chain, and carries a TODO to remove once a reachable release exists.

**Reachability:** `quick-xml` here only parses XML that `rust-s3` receives from the configured S3-compatible endpoint (error and list responses). Triggering either DoS requires the object-storage backend to return crafted XML -- a trusted, operator-configured endpoint rather than arbitrary attacker input -- so the practical exposure for koto is low.

## Verification

- `cargo audit` -- clean, exit 0 (0 vulnerabilities; 3 allowed warnings)
- `cargo build` -- pass
- `cargo test` -- pass
- `cargo clippy -- -D warnings` -- pass (matches the CI clippy step)
- `cargo fmt --check` -- pass
- All PR CI checks green, including `Audit`

## Checklist

- [x] If `EventPayload` variants or `StateFileHeader` fields were added, removed, or
      renamed: `docs/reference/session-feed.md` frontmatter and body updated to match.
      (No such changes in this PR -- dependency and audit-config only.)

Fixes #175
