### PR TITLE
ci: move perf benches to nightly, off the required PR path

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -1,0 +1,69 @@
+name: benches
+
+# Criterion performance benches, moved off the per-PR critical path.
+#
+# These two jobs each run `cargo bench` across workspace sizes up to 26k
+# sessions on a 2-vCPU runner, taking ~13-16 min per run. They are
+# reporting-only (KOTO_BENCH_STRICT is unset): on a threshold breach they
+# print `BREACH` to stderr but exit 0, so they cannot fail a run on
+# performance. Keeping them on every PR added ~13-16 min of latency to the
+# required `validate` gate for no enforcement value, so they now run:
+#   - nightly on a schedule (catches regressions on `main` daily), and
+#   - on every push to `main` (post-merge signal).
+# They no longer run on pull requests.
+on:
+  schedule:
+    # 07:00 UTC daily -- a low-traffic window (late evening in the
+    # Americas, early morning in Europe) so a ~30 min bench run does not
+    # contend with weekday PR CI.
+    - cron: '0 7 * * *'
+  push:
+    branches: [main]
+
+jobs:
+  discovery-bench:
+    # Issue 10: criterion bench harness for the discovery scan.
+    # Runs the warm-cursor + cold-cursor groups at 100/1k/10k/26k
+    # workspace sizes. Threshold gating is REPORTING-ONLY by default
+    # (KOTO_BENCH_STRICT is unset); the bench emits `BREACH` lines to
+    # stderr but exits 0 so the harness lands without producing a
+    # red-on-main signal while the perf-optimization issue is open.
+    # See `benches/discovery_scan.rs` file-header "Gate-enforcement
+    # mode" for the rationale and the path to strict enforcement.
+    name: Discovery Bench
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run discovery scan bench
+        # `--save-baseline ci` lets criterion compare each run
+        # against the prior CI baseline. Combined with the bench's own
+        # gate (reporting-only by default), this gives a two-tier
+        # signal: criterion's regression detector AND the absolute
+        # thresholds.
+        run: cargo bench --bench discovery_scan -- --save-baseline ci
+
+  recursion-caps-bench:
+    # Issue 17: criterion bench harness for the recursion-cap
+    # validator at 1k/10k/26k workspace sizes with 100 open sessions.
+    # The 26k case measures the AD3.3 perf-cliff avoidance commitment
+    # (30 ms p95 target). Soft-by-default like Issue 10's bench; the
+    # current implementation breaches because `read_terminal_index`
+    # walks the full JSONL file -- a follow-up optimization (either an
+    # O(open-sessions) counter primitive or a smarter index format)
+    # closes the gap. Once closed, flip KOTO_BENCH_STRICT=1 to harden.
+    name: Recursion Caps Bench
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run recursion caps bench
+        run: cargo bench --bench recursion_caps -- --save-baseline ci

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -184,58 +184,9 @@ jobs:
           fi
           cargo test --features cloud-integration-tests --test cloud_integration_test -- --test-threads=1
 
-  discovery-bench:
-    # Issue 10: criterion bench harness for the discovery scan.
-    # Runs the warm-cursor + cold-cursor groups at 100/1k/10k/26k
-    # workspace sizes. Threshold gating is REPORTING-ONLY by default
-    # (KOTO_BENCH_STRICT is unset); the bench emits `BREACH` lines to
-    # stderr but exits 0 so the harness lands without producing a
-    # red-on-main signal while the perf-optimization issue is open.
-    # See `benches/discovery_scan.rs` file-header "Gate-enforcement
-    # mode" for the rationale and the path to strict enforcement.
-    name: Discovery Bench
-    if: ${{ github.event.pull_request.draft != true }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Run discovery scan bench
-        # `--save-baseline ci` lets criterion compare each PR's run
-        # against the prior CI baseline. Combined with the bench's own
-        # gate (reporting-only by default), this gives a two-tier
-        # signal: criterion's regression detector AND the absolute
-        # thresholds.
-        run: cargo bench --bench discovery_scan -- --save-baseline ci
-
-  recursion-caps-bench:
-    # Issue 17: criterion bench harness for the recursion-cap
-    # validator at 1k/10k/26k workspace sizes with 100 open sessions.
-    # The 26k case measures the AD3.3 perf-cliff avoidance commitment
-    # (30 ms p95 target). Soft-by-default like Issue 10's bench; the
-    # current implementation breaches because `read_terminal_index`
-    # walks the full JSONL file — a follow-up optimization (either an
-    # O(open-sessions) counter primitive or a smarter index format)
-    # closes the gap. Once closed, flip KOTO_BENCH_STRICT=1 to harden.
-    name: Recursion Caps Bench
-    if: ${{ github.event.pull_request.draft != true }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Run recursion caps bench
-        run: cargo bench --bench recursion_caps -- --save-baseline ci
-
   validate:
     name: validate
-    needs: [check-artifacts, unit-tests, stability-tests, fmt, clippy, audit, tsuku-distributed-install, cloud-integration, discovery-bench, recursion-caps-bench]
+    needs: [check-artifacts, unit-tests, stability-tests, fmt, clippy, audit, tsuku-distributed-install, cloud-integration]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Moves the two criterion performance benches off the per-PR critical path so
pull requests stop waiting ~13-16 min on them, and runs them nightly (plus on
push to `main`) instead.

Both `Discovery Bench` (`discovery-bench`) and `Recursion Caps Bench`
(`recursion-caps-bench`) run `cargo bench` across workspace sizes up to 26k
sessions on a 2-vCPU runner, ~13-16 min each — the single slowest thing gating
every PR. That cost is inherent to the bench (statistical sampling x 4 sizes x
2 regimes x large on-disk fixtures), not a regression.

Both benches are reporting-only today: `KOTO_BENCH_STRICT` is unset, so on a
threshold breach they print `BREACH` to stderr but exit 0 — they cannot fail a
run on performance. On the required `validate` gate they added latency without
any enforcement value.

What changed:

- **New `.github/workflows/benches.yml`** — both bench jobs moved verbatim
  (same steps, same `cargo bench … --save-baseline ci` commands, same
  toolchain/cache), triggered on a nightly `schedule` (`0 7 * * *`, 07:00 UTC —
  a low-traffic window) and on `push` to `main`. Their `pull_request.draft`
  guard is dropped since they no longer run on PRs. They stay reporting-only
  (`KOTO_BENCH_STRICT` remains unset).
- **`.github/workflows/validate.yml`** — both bench job definitions removed and
  dropped from the `validate` aggregator's `needs:` list. The aggregator's
  `Check results` shell already inspected only the remaining required jobs, so
  it still fails correctly on genuine failures of those jobs.

Bench pass/fail semantics are unchanged: no `KOTO_BENCH_STRICT`, no threshold
changes, no edits to `benches/*.rs`. A daily run on `main` still catches
regressions with zero PR latency.

---

## Branch-protection follow-up (maintainer action)

`main`'s required status checks currently list only **`validate`**
(`repos/tsukumogami/koto/branches/main` reports
`required_status_checks.contexts = ["validate"]`), and `validate` still runs and
reports on every PR after this change — so PR merges are **not** blocked by this
change. The individual `Discovery Bench` / `Recursion Caps Bench` job names are
**not** required checks, so no branch-protection edit is required to unblock
merges.

Note: I could not read the full branch-protection object (token lacks admin
read: `GET …/branches/main/protection` returned 403), so the above is from the
non-admin `branches/main` summary. If a required check named `Discovery Bench`
or `Recursion Caps Bench` does exist and isn't surfaced there, it would need to
be removed from branch protection — please confirm on merge.

## How to verify

- On this PR, the required `validate` check goes green without waiting on either
  bench; neither bench job appears on the PR's checks.
- `actionlint` passes on both `benches.yml` and `validate.yml`.
- After merge, `benches.yml` runs on the push to `main` and then nightly at
  07:00 UTC.

## Out of scope

Unrelated to the recently merged native-`/workflows` work (#178). No bench
sources, thresholds, or strict-mode settings touched.
