### PR TITLE
feat(substitute): allow :, @, and spaces in --var values

### DIFF
--- a/plugins/koto-skills/skills/koto-author/references/template-format.md
+++ b/plugins/koto-skills/skills/koto-author/references/template-format.md
@@ -731,7 +731,16 @@ For a template at `koto-templates/my-skill.md`, the preview goes at `koto-templa
 
 ## Security note
 
-Koto performs `{{VARIABLE}}` substitution in `command` gate strings before passing them to `sh -c`. If a variable contains user-supplied input, this creates a shell injection risk.
+Koto performs `{{VARIABLE}}` substitution in `command` gate strings before passing them to `sh -c`. Values supplied via `--var` are validated at init time against an allowlist (letters, digits, `. _ - /`, `:`, `@`, and spaces); shell metacharacters such as `;` `|` `&` `$` `(` `)` `<` `>` `*` `?`, quotes, backticks, and newlines are rejected, so a value cannot inject a command.
+
+The allowlist blocks command injection, not word splitting. A value may contain spaces (for structured names like a calendar title), and an unquoted interpolation splits it into multiple shell arguments. Quote the reference when a value must stay a single argument:
+
+```yaml
+# A value like "Weekly Planning" splits into two arguments here:
+command: mytool --calendar {{CALENDAR}}
+# Quote it to keep it one argument:
+command: mytool --calendar "{{CALENDAR}}"
+```
 
 Prefer `context-exists` gates over `command` gates when checking paths or files that come from variable interpolation. The `context-exists` and `context-matches` gate types don't invoke a shell and aren't vulnerable to injection.
 

--- a/plugins/koto-skills/skills/koto-user/references/command-reference.md
+++ b/plugins/koto-skills/skills/koto-user/references/command-reference.md
@@ -53,7 +53,7 @@ Initializes a new workflow. Provide the definition one of two ways:
 | `--template <path>` | One of `--template` / `--from-stdin` | Path to the template `.md` source file. Compiled automatically on first use. |
 | `--from-stdin` | One of `--template` / `--from-stdin` | Read the workflow definition from stdin, strict-compile it into the session directory, and start the session. **Mutually exclusive** with `--template`. **Rejects** `--allow-legacy-gates` (the inline path is strict-only). Does not support `--parent`. |
 | `--parent <parent-name>` | No | Link this workflow as a child of an existing parent workflow. Fails if the parent doesn't exist. Not available with `--from-stdin`. |
-| `--var KEY=VALUE` | No | Set a template variable. Repeatable. Required variables must be supplied; unknown keys are rejected. |
+| `--var KEY=VALUE` | No | Set a template variable. Repeatable. Required variables must be supplied; unknown keys are rejected. VALUE is checked against an allowlist (see Notes). |
 
 **Success output:**
 ```json
@@ -66,6 +66,7 @@ Initializes a new workflow. Provide the definition one of two ways:
 - Exit 1: a `--from-stdin` definition that fails strict validation. No session is created, the process exits non-zero, and the error **names the failing element** (state / transition / gate) — for example `state "start" references undefined transition target "nowhere"` — so you can correct the definition and re-pipe it.
 
 **Notes:**
+- `--var` values are validated against an allowlist because a substituted `{{KEY}}` can land in a gate command (run via `sh -c`) or an agent instruction. Allowed characters: letters, digits, `. _ - /`, `:`, `@`, and spaces. This covers structured data values such as Gmail filters (`newer_than:90d`, `from:user@example.com`) and names with spaces (a calendar title). Shell metacharacters -- `;` `|` `&` `$` `(` `)` `<` `>` `*` `?`, quotes, backticks, and newlines -- are **rejected** so a value cannot inject a command. A space is allowed but is not shell-quoted for you: when a value may contain spaces, quote the reference in the template (e.g. `--calendar "{{CALENDAR}}"`) so it stays a single argument.
 - Reserved variable names `SESSION_DIR` and `SESSION_NAME` cannot be declared in templates. They are injected automatically.
 - If a `--template` source uses legacy-mode gates (no `gates.*` when-clause routing), `koto init` emits a warning to **stderr** and still succeeds. The `--from-stdin` path is strict: a legacy gate is **rejected**, naming the offending state and gate.
 - `--from-stdin` writes both the compiled artifact and the human-readable source into the session directory (the source under a fixed filename), so the workflow survives global cache eviction and the authored definition stays recoverable for audit. Do not embed secrets in the definition; reference `$VAR` / files read at gate-evaluation time instead.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -109,7 +109,10 @@ pub enum Command {
         #[arg(long)]
         allow_legacy_gates: bool,
 
-        /// Set a template variable (repeatable)
+        /// Set a template variable (repeatable). VALUE accepts letters,
+        /// digits, and `. _ - / : @` plus spaces; shell metacharacters are
+        /// rejected. Quote `{{KEY}}` in gate commands when a value may contain
+        /// spaces.
         #[arg(long = "var", value_name = "KEY=VALUE")]
         vars: Vec<String>,
 

--- a/src/engine/substitute.rs
+++ b/src/engine/substitute.rs
@@ -5,9 +5,28 @@ use regex::Regex;
 use crate::engine::types::{Event, EventPayload};
 use crate::template::types::VAR_REF_PATTERN;
 
-/// Allowlist regex for variable values: alphanumeric, dots, underscores, hyphens, forward slashes.
+/// Allowlist regex for variable values.
+///
+/// A substituted `{{KEY}}` value can land in a `sh -c` gate command or an agent
+/// instruction, so the value set is an allowlist, not a denylist: every
+/// character that could execute a command, trigger an expansion, or redirect
+/// I/O stays out by default. The set is deliberately conservative -- widen it
+/// only with a per-character justification.
+///
+/// Allowed characters:
+/// - `a-z A-Z 0-9` and `. _ -` -- identifiers, versions, filenames.
+/// - `/` -- path separators (e.g. `org/repo`).
+/// - `:` `@` -- structured data values such as Gmail filters (`newer_than:90d`,
+///   `from:user@example.com`). Neither is a shell metacharacter, so both are
+///   literal inside a `sh -c` word (Issue #180).
+/// - space -- structured names such as a calendar title. A space is not a
+///   command-injection vector: it introduces no command, expansion, or
+///   redirection. Its only effect in an unquoted interpolation is word
+///   splitting, so template authors should quote `{{KEY}}` where a value must
+///   stay a single shell argument (Issue #180).
+///
 /// Empty strings are allowed for optional variables with no default (Issue #141).
-const VALUE_PATTERN: &str = r"^[a-zA-Z0-9._/\-]*$";
+const VALUE_PATTERN: &str = r"^[a-zA-Z0-9._/:@ \-]*$";
 
 /// Holds resolved variable bindings for substitution.
 #[derive(Debug)]
@@ -127,10 +146,21 @@ mod tests {
     }
 
     #[test]
-    fn validate_value_rejects_spaces() {
-        let err = validate_value("KEY", "hello world").unwrap_err();
-        assert_eq!(err.key, "KEY");
-        assert_eq!(err.value, "hello world");
+    fn validate_value_accepts_spaces() {
+        // Spaces are allowed for structured data values such as a calendar name
+        // (Issue #180). A space introduces no shell command, expansion, or
+        // redirection; its only effect in an unquoted interpolation is word
+        // splitting, which template authors control by quoting `{{KEY}}`.
+        validate_value("KEY", "Weekly Planning").unwrap();
+    }
+
+    #[test]
+    fn validate_value_accepts_colon_and_at() {
+        // Colon and at-sign are not shell metacharacters, so they are literal
+        // inside a `sh -c` word. They unblock structured values like Gmail
+        // search filters (Issue #180).
+        validate_value("SINCE", "newer_than:90d").unwrap();
+        validate_value("FROM", "from:delta@delta.com").unwrap();
     }
 
     #[test]
@@ -141,9 +171,22 @@ mod tests {
 
     #[test]
     fn validate_value_rejects_special_chars() {
-        validate_value("KEY", "value;rm -rf").unwrap_err();
-        validate_value("KEY", "$(evil)").unwrap_err();
-        validate_value("KEY", "a\nb").unwrap_err();
+        // The allowlist must keep out every character that can execute a
+        // command, trigger an expansion, or redirect I/O once the value lands
+        // in a `sh -c` gate command or an agent instruction (Issue #180 keeps
+        // this guarantee intact while widening the safe set).
+        validate_value("KEY", "value;rm -rf").unwrap_err(); // command separator
+        validate_value("KEY", "$(evil)").unwrap_err(); // command substitution
+        validate_value("KEY", "`evil`").unwrap_err(); // backtick substitution
+        validate_value("KEY", "a\nb").unwrap_err(); // newline
+        validate_value("KEY", "a|b").unwrap_err(); // pipe
+        validate_value("KEY", "a&b").unwrap_err(); // background / and-list
+        validate_value("KEY", "a>b").unwrap_err(); // redirection
+        validate_value("KEY", "a*b").unwrap_err(); // glob
+        validate_value("KEY", "${HOME}").unwrap_err(); // parameter expansion
+        validate_value("KEY", "a'b").unwrap_err(); // single quote
+        validate_value("KEY", "a\"b").unwrap_err(); // double quote
+        validate_value("KEY", "a\\b").unwrap_err(); // backslash
     }
 
     // -----------------------------------------------------------------------
@@ -291,7 +334,7 @@ mod tests {
             event_type: "workflow_initialized".to_string(),
             payload: EventPayload::WorkflowInitialized {
                 template_path: "/cache/abc.json".to_string(),
-                variables: HashMap::from([("BAD".to_string(), "has spaces".to_string())]),
+                variables: HashMap::from([("BAD".to_string(), "value;rm -rf".to_string())]),
                 spawn_entry: None,
             },
             idempotency_hash: None,
@@ -299,6 +342,32 @@ mod tests {
 
         let err = Variables::from_events(&events).unwrap_err();
         assert_eq!(err.key, "BAD");
+    }
+
+    #[test]
+    fn from_events_accepts_structured_data_values() {
+        // The motivating Issue #180 values: a Gmail window, a sender filter
+        // with a colon and `@`, and a calendar name with spaces.
+        let events = vec![Event {
+            seq: 1,
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+            event_type: "workflow_initialized".to_string(),
+            payload: EventPayload::WorkflowInitialized {
+                template_path: "/cache/abc.json".to_string(),
+                variables: HashMap::from([
+                    ("SINCE".to_string(), "newer_than:90d".to_string()),
+                    ("FROM".to_string(), "from:delta@delta.com".to_string()),
+                    ("CALENDAR".to_string(), "Weekly Planning".to_string()),
+                ]),
+                spawn_entry: None,
+            },
+            idempotency_hash: None,
+        }];
+
+        let vars = Variables::from_events(&events).unwrap();
+        assert_eq!(vars.substitute("{{SINCE}}"), "newer_than:90d");
+        assert_eq!(vars.substitute("{{FROM}}"), "from:delta@delta.com");
+        assert_eq!(vars.substitute("{{CALENDAR}}"), "Weekly Planning");
     }
 
     #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3365,7 +3365,7 @@ fn init_var_forbidden_chars_fail() {
             "--template",
             src.to_str().unwrap(),
             "--var",
-            "OWNER=acme corp",
+            "OWNER=acme;rm -rf",
             "--var",
             "REPO=widgets",
         ])
@@ -3374,7 +3374,7 @@ fn init_var_forbidden_chars_fail() {
 
     assert!(
         !output.status.success(),
-        "forbidden characters in value should fail"
+        "shell metacharacters in value should fail"
     );
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let err = json["error"].as_str().unwrap();
@@ -3383,6 +3383,47 @@ fn init_var_forbidden_chars_fail() {
         "error should mention not allowed, got: {}",
         err
     );
+}
+
+#[test]
+fn init_var_structured_data_values_accepted() {
+    // Issue #180: structured data values with `:`, `@`, and spaces are
+    // accepted through the CLI and stored verbatim in the init event, while
+    // the injection guard still rejects shell metacharacters (covered by
+    // init_var_forbidden_chars_fail).
+    let dir = TempDir::new().unwrap();
+    let src = write_var_template_source(dir.path());
+
+    let output = koto_cmd(dir.path())
+        .args([
+            "init",
+            "var-wf",
+            "--template",
+            src.to_str().unwrap(),
+            "--var",
+            "OWNER=from:delta@delta.com",
+            "--var",
+            "REPO=widgets",
+            "--var",
+            "BRANCH=Weekly Planning",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "init with structured data values should succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let state_path = session_state_path(dir.path(), "var-wf");
+    let content = std::fs::read_to_string(&state_path).unwrap();
+    let lines: Vec<&str> = content.lines().collect();
+    let init_event: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+    let vars = init_event["payload"]["variables"].as_object().unwrap();
+    assert_eq!(vars["OWNER"].as_str(), Some("from:delta@delta.com"));
+    assert_eq!(vars["BRANCH"].as_str(), Some("Weekly Planning"));
 }
 
 #[test]


### PR DESCRIPTION
`koto init --var KEY=VALUE` validated VALUE against a conservative allowlist
(`^[a-zA-Z0-9._/\-]*$`) with no escape hatch, so legitimate structured values
containing `:`, `@`, or spaces could not be passed as template variables at all.
The motivating case (Refs #180) is a workflow that parameterizes a Gmail search
window (`newer_than:90d`), a sender filter (`from:user@example.com`), and a
calendar name with spaces. This widens the allowlist with a vetted set of three
characters while keeping the injection guarantee intact for values that reach a
shell or an agent instruction.

The allowlist stays an allowlist, not a denylist: every shell metacharacter that
can execute a command, trigger an expansion, or redirect I/O is still rejected by
default. `value;rm -rf` and `$(evil)` are still refused, verified end-to-end and
in tests.

---

## Why this is safe (per-character justification)

A substituted `{{KEY}}` value can land in a `command` gate string that runs via
`sh -c` (`src/cli/mod.rs` -> `run_shell_command`) or in an agent directive, so
the guard is real. The new pattern is `^[a-zA-Z0-9._/:@ \-]*$`:

- **`:` (colon)** and **`@` (at-sign)** are not shell metacharacters. Inside a
  `sh -c` word they are literal -- they introduce no command, expansion, or
  redirection. They unblock `newer_than:90d` and `from:user@example.com`. Zero
  command-injection surface.
- **space** unblocks structured names such as a calendar title. A space is not a
  command-injection vector: it cannot execute a command or trigger an expansion.
  Its only effect in an *unquoted* interpolation is word splitting -- the value
  becomes multiple shell arguments. That is a correctness concern the template
  author controls by quoting `{{KEY}}`, of the same class already reachable via
  the long-allowed hyphen (argument injection). It does not let a value run an
  arbitrary command, which is what the guard exists to prevent.

Everything else that could inject a command stays blocked: `;`, `|`, `&`, `$`,
backticks, `(` `)`, `<` `>`, `*` `?`, `{` `}`, quotes, backslash, newline, and
any other unlisted character. Because the model remains an allowlist, characters
not explicitly vetted here are still rejected by default.

Comma was listed as a candidate in the issue but is omitted -- no motivating
value needs it (YAGNI); it can be added later with the same justification.

## What changed

- **`src/engine/substitute.rs`** -- widen `VALUE_PATTERN` to
  `^[a-zA-Z0-9._/:@ \-]*$`; rewrite the doc comment to justify each character and
  document the word-splitting caveat. This is the single choke point:
  `validate_value` is enforced at `koto init` time and re-validated in
  `Variables::from_events` as defense in depth.
- **`src/cli/mod.rs`** -- expand the `--var` help text to describe the accepted
  set and the quoting guidance.
- **Docs** -- `command-reference.md` (koto-user) and `template-format.md`
  (koto-author) now document the allowlist and the "quote `{{KEY}}` for values
  with spaces" guidance, keeping both skills in sync with the code.

## Tests

- `substitute.rs`: `validate_value_rejects_spaces` becomes
  `validate_value_accepts_spaces`; added `validate_value_accepts_colon_and_at`
  and `from_events_accepts_structured_data_values` for the three motivating
  values; expanded `validate_value_rejects_special_chars` to assert continued
  rejection of a broad set of injection payloads (command separator, command
  substitution, backticks, pipe, background, redirection, glob, parameter
  expansion, quotes, backslash, newline).
- `integration_test.rs`: `init_var_forbidden_chars_fail` now uses a real shell
  metacharacter payload (`acme;rm -rf`); added
  `init_var_structured_data_values_accepted` driving the CLI with `:`, `@`, and
  a space and asserting the values are stored verbatim in the init event.

## How to verify

- `cargo test`, `cargo fmt --check`, and `cargo clippy -- -D warnings` all pass.
- End-to-end with the release binary: `koto init` accepts
  `--var SINCE=newer_than:90d --var FROM=from:delta@delta.com --var 'CALENDAR=Weekly Planning'`
  (exit 0, values stored verbatim), and rejects
  `--var SINCE='x;rm -rf /'` and `--var 'SINCE=$(evil)'` (exit 2, "contains
  characters not allowed by the value pattern").
