### PR TITLE
fix(workflows): global config opt-in with env self-discovery

### DIFF
--- a/docs/guides/cli-usage.md
+++ b/docs/guides/cli-usage.md
@@ -599,8 +599,11 @@ koto config list --json
 | `session.cloud.region` | AWS region | -- | yes |
 | `session.cloud.access_key` | Access key ID | -- | no |
 | `session.cloud.secret_key` | Secret access key | -- | no |
+| `workflows.native` | `true`, `false` | `false` | yes |
 
 Credential keys (`access_key`, `secret_key`) can also be provided through environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. Environment variables take precedence over config file values.
+
+`workflows.native` opts in to rendering koto sessions in Claude Code's `/workflows` screen (see [native-workflows-verification.md](native-workflows-verification.md)); a participating session self-discovers its target directory from `CLAUDE_CODE_SESSION_ID`.
 
 #### Example: local-only config (default)
 

--- a/docs/guides/native-workflows-verification.md
+++ b/docs/guides/native-workflows-verification.md
@@ -47,46 +47,51 @@ for its version/fixture guard over the undocumented surface.
 This confirms the one thing the automated check cannot: that Claude Code renders
 the emitted file.
 
-1. **Enable the hook.** Ensure the `koto-skills` plugin is installed so its
-   `SessionStart` hook runs. On session start it announces the workflows
-   directory for the current Claude Code session.
+1. **Enable rendering (once).** Opt in with a config flag:
 
-2. **Point koto at the directory.** Export the announced path so koto processes
-   inherit it:
+   ```bash
+   koto config set workflows.native true --user
+   ```
+
+   With this set, a koto session driven inside a Claude Code session
+   self-discovers that session's workflows directory from the
+   `CLAUDE_CODE_SESSION_ID` environment variable Claude Code sets in every
+   subprocess — no plugin, hook, or manual export required. It stays off by
+   default, so koto's normal path is untouched until you opt in.
+
+   *Alternative (explicit handoff):* instead of the config flag, export the
+   directory directly — useful for a headless host or a non-standard layout:
 
    ```bash
    export KOTO_WORKFLOWS_DIR="<projectDir>/<sessionId>/workflows"
    ```
 
-   (The hook prints the exact `export` line. `<projectDir>` is the directory of
-   the session's transcript; `<sessionId>` is the Claude Code session id.)
-
-3. **Drive a koto session.** In the same Claude Code session, run a workflow:
+2. **Drive a koto session.** In the same Claude Code session, run a workflow:
 
    ```bash
    koto init demo --template <template> --intent "demo"
    koto next demo
    ```
 
-4. **Open `/workflows`.** The koto session appears as an entry named for the
+3. **Open `/workflows`.** The koto session appears as an entry named for the
    session, showing its phases in order with the active one marked, the active
    phase's directive, and — for a multi-phase workflow — each completed phase's
    evidence or gate outcome.
 
-5. **Advance and reopen.** Run `koto next demo` again, then reopen
+4. **Advance and reopen.** Run `koto next demo` again, then reopen
    `/workflows` — the active-phase marker moves to the new phase, the previously
    active phase shows its outcome, and the directive updates (refresh-on-open).
 
-6. **Block on a gate and reopen.** Drive the session into a state whose gate
+5. **Block on a gate and reopen.** Drive the session into a state whose gate
    does not pass, then reopen `/workflows` — the entry reads *blocked*, not a
    spinning *running* and not *done*.
 
-7. **Complete and reopen.** Drive the session to its terminal state, then reopen
+6. **Complete and reopen.** Drive the session to its terminal state, then reopen
    `/workflows` — the entry reads *done* (completed), not a stuck *running*.
 
-8. **Negative check.** In a plain terminal (no `KOTO_WORKFLOWS_DIR`, no hook),
-   run a koto session and confirm `/workflows` is unaffected and no
-   `koto-*.json` is written.
+7. **Negative check.** With rendering disabled (`workflows.native` unset and no
+   `KOTO_WORKFLOWS_DIR`), run a koto session and confirm `/workflows` is
+   unaffected and no `koto-*.json` is written.
 
 ## Notes
 

--- a/plugins/koto-skills/skills/koto-user/references/command-reference.md
+++ b/plugins/koto-skills/skills/koto-user/references/command-reference.md
@@ -572,7 +572,7 @@ koto config list                 # Print merged config as TOML
 koto config list --json          # Print merged config as JSON
 ```
 
-Valid key paths: `session.backend`, `session.cloud.endpoint`, `session.cloud.bucket`, `session.cloud.region`, `session.cloud.access_key`, `session.cloud.secret_key`.
+Valid key paths: `session.backend`, `session.cloud.endpoint`, `session.cloud.bucket`, `session.cloud.region`, `session.cloud.access_key`, `session.cloud.secret_key`, `workflows.native`.
 
 ---
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,6 +10,23 @@ pub struct KotoConfig {
     pub session: SessionConfig,
     #[serde(default)]
     pub request_store: RequestStoreConfig,
+    #[serde(default)]
+    pub workflows: WorkflowsConfig,
+}
+
+/// Native Claude Code `/workflows` rendering configuration.
+///
+/// `native` is the global opt-in for rendering koto sessions in Claude Code's
+/// `/workflows` screen. When true, a session driven inside a Claude Code
+/// session self-discovers that session's workflows directory from the
+/// `CLAUDE_CODE_SESSION_ID` environment variable and renders into it -- no
+/// SessionStart hook or plugin required. Defaults to false, so koto's default
+/// path is untouched until an operator opts in (`koto config set
+/// workflows.native true --user`).
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
+pub struct WorkflowsConfig {
+    #[serde(default)]
+    pub native: bool,
 }
 
 /// Request-store (coordinator/operator) configuration.
@@ -151,6 +168,7 @@ pub fn get_value(config: &KotoConfig, key: &str) -> Option<String> {
         "request_store.respawn_generation_cap" => {
             Some(config.request_store.respawn_generation_cap.to_string())
         }
+        "workflows.native" => Some(config.workflows.native.to_string()),
         _ => None,
     }
 }
@@ -239,6 +257,16 @@ pub fn set_value_in_toml(doc: &mut toml::Value, key: &str, value: &str) -> Resul
                 .ok_or("request_store.recursion is not a table")?;
             recursion_table.insert(field.to_string(), toml_value);
         }
+        "workflows.native" => {
+            let parsed: bool = value
+                .parse()
+                .map_err(|_| format!("value for {} must be true or false", key))?;
+            let workflows = table
+                .entry("workflows")
+                .or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
+            let workflows_table = workflows.as_table_mut().ok_or("workflows is not a table")?;
+            workflows_table.insert("native".to_string(), toml::Value::Boolean(parsed));
+        }
         _ => return Err(format!("unknown config key: {}", key)),
     }
     Ok(())
@@ -307,6 +335,14 @@ pub fn unset_value_in_toml(doc: &mut toml::Value, key: &str) -> Result<bool, Str
             }
             Ok(false)
         }
+        "workflows.native" => {
+            if let Some(workflows) = table.get_mut("workflows") {
+                if let Some(t) = workflows.as_table_mut() {
+                    return Ok(t.remove("native").is_some());
+                }
+            }
+            Ok(false)
+        }
         _ => Err(format!("unknown config key: {}", key)),
     }
 }
@@ -327,6 +363,7 @@ pub const ALL_KEYS: &[&str] = &[
     "request_store.compact_lock_timeout_seconds",
     "request_store.directive_batch_size",
     "request_store.respawn_generation_cap",
+    "workflows.native",
 ];
 
 /// Produce a redacted copy of the config for display.
@@ -605,5 +642,60 @@ mod tests {
         set_value_in_toml(&mut doc, "request_store.recursion.max_depth", "10").unwrap();
         let removed = unset_value_in_toml(&mut doc, "request_store.recursion.max_depth").unwrap();
         assert!(removed);
+    }
+
+    // -----------------------------------------------------------------------
+    // workflows.native opt-in coverage
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_workflows_native_defaults_false() {
+        let config = KotoConfig::default();
+        assert!(!config.workflows.native);
+        assert_eq!(
+            get_value(&config, "workflows.native"),
+            Some("false".to_string())
+        );
+    }
+
+    #[test]
+    fn test_set_and_get_workflows_native() {
+        let mut doc = toml::Value::Table(toml::map::Map::new());
+        set_value_in_toml(&mut doc, "workflows.native", "true").unwrap();
+        let cfg: KotoConfig = doc.try_into().unwrap();
+        assert!(cfg.workflows.native);
+        assert_eq!(
+            get_value(&cfg, "workflows.native"),
+            Some("true".to_string())
+        );
+    }
+
+    #[test]
+    fn test_workflows_native_partial_toml_uses_defaults() {
+        // A config that only sets request_store leaves workflows.native false.
+        let toml_str = "[request_store]\nredelegation_cap = 5\n";
+        let cfg: KotoConfig = toml::from_str(toml_str).unwrap();
+        assert!(!cfg.workflows.native);
+    }
+
+    #[test]
+    fn test_set_workflows_native_rejects_non_bool() {
+        let mut doc = toml::Value::Table(toml::map::Map::new());
+        let err = set_value_in_toml(&mut doc, "workflows.native", "yes")
+            .expect_err("non-bool must reject");
+        assert!(err.contains("must be true or false"));
+    }
+
+    #[test]
+    fn test_unset_workflows_native_round_trips() {
+        let mut doc = toml::Value::Table(toml::map::Map::new());
+        set_value_in_toml(&mut doc, "workflows.native", "true").unwrap();
+        assert!(unset_value_in_toml(&mut doc, "workflows.native").unwrap());
+        assert!(!unset_value_in_toml(&mut doc, "workflows.native").unwrap());
+    }
+
+    #[test]
+    fn test_workflows_native_in_all_keys() {
+        assert!(ALL_KEYS.contains(&"workflows.native"));
     }
 }

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -181,10 +181,17 @@ fn load_config_file(path: &Path) -> Result<LoadedConfig> {
         .and_then(|v| v.as_table())
         .and_then(|t| t.get("recursion"))
         .is_some();
+    let workflows_native_present = raw
+        .as_table()
+        .and_then(|t| t.get("workflows"))
+        .and_then(|v| v.as_table())
+        .map(|t| t.contains_key("native"))
+        .unwrap_or(false);
     Ok(LoadedConfig {
         config,
         request_store_keys,
         request_store_has_recursion,
+        workflows_native_present,
     })
 }
 
@@ -194,6 +201,7 @@ struct LoadedConfig {
     config: KotoConfig,
     request_store_keys: Vec<String>,
     request_store_has_recursion: bool,
+    workflows_native_present: bool,
 }
 
 /// Merge source config into target. Non-default/non-empty values in
@@ -259,6 +267,9 @@ fn merge_config(target: &mut KotoConfig, source: &LoadedConfig) {
     }
     if source.request_store_has_recursion {
         target.request_store.recursion = source.config.request_store.recursion.clone();
+    }
+    if source.workflows_native_present {
+        target.workflows.native = source.config.workflows.native;
     }
 }
 
@@ -377,9 +388,11 @@ mod tests {
                     },
                 },
                 request_store: RequestStoreConfig::default(),
+                workflows: Default::default(),
             },
             request_store_keys: vec![],
             request_store_has_recursion: false,
+            workflows_native_present: false,
         };
 
         merge_config(&mut base, &overlay);
@@ -397,6 +410,7 @@ mod tests {
             config: KotoConfig::default(),
             request_store_keys: vec![],
             request_store_has_recursion: false,
+            workflows_native_present: false,
         };
         merge_config(&mut base, &overlay);
 
@@ -405,6 +419,58 @@ mod tests {
         // The merge only overwrites if source backend is non-empty.
         assert_eq!(base.session.backend, "cloud");
         assert_eq!(base.session.cloud.bucket, Some("existing".to_string()));
+    }
+
+    #[test]
+    fn test_workflows_native_parsed_and_tracked_from_file() {
+        // Race-free: load_config_file reads a specific path, touching no
+        // process-global cwd/env.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        fs::write(&path, "[workflows]\nnative = true\n").unwrap();
+
+        let loaded = load_config_file(&path).unwrap();
+        assert!(loaded.config.workflows.native);
+        assert!(loaded.workflows_native_present);
+    }
+
+    #[test]
+    fn test_workflows_native_absent_not_tracked() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        fs::write(&path, "[session]\nbackend = \"local\"\n").unwrap();
+
+        let loaded = load_config_file(&path).unwrap();
+        assert!(!loaded.config.workflows.native);
+        assert!(!loaded.workflows_native_present);
+    }
+
+    #[test]
+    fn test_merge_applies_workflows_native_only_when_present() {
+        // present=true flips the base on.
+        let mut base = KotoConfig::default();
+        let mut on = KotoConfig::default();
+        on.workflows.native = true;
+        let overlay = LoadedConfig {
+            config: on.clone(),
+            request_store_keys: vec![],
+            request_store_has_recursion: false,
+            workflows_native_present: true,
+        };
+        merge_config(&mut base, &overlay);
+        assert!(base.workflows.native);
+
+        // present=false must NOT overwrite an already-on base.
+        let mut base_on = KotoConfig::default();
+        base_on.workflows.native = true;
+        let overlay_absent = LoadedConfig {
+            config: KotoConfig::default(),
+            request_store_keys: vec![],
+            request_store_has_recursion: false,
+            workflows_native_present: false,
+        };
+        merge_config(&mut base_on, &overlay_absent);
+        assert!(base_on.workflows.native, "absent key must not clobber");
     }
 
     #[test]

--- a/src/workflows_surface/materialize.rs
+++ b/src/workflows_surface/materialize.rs
@@ -30,6 +30,11 @@ const PREVIEW_MAX: usize = 240;
 /// `SessionStart` hook hands koto the session's `/workflows` directory.
 pub const WORKFLOWS_DIR_ENV: &str = "KOTO_WORKFLOWS_DIR";
 
+/// Environment variable Claude Code sets to the viewing session's id in every
+/// subprocess. Under the `workflows.native` opt-in, koto self-discovers the
+/// session's `/workflows` directory from it -- no `SessionStart` hook required.
+const CLAUDE_SESSION_ID_ENV: &str = "CLAUDE_CODE_SESSION_ID";
+
 /// Materialize `session_id`'s `/workflows` artifact after a state-commit.
 ///
 /// Best-effort: any failure is logged and swallowed so the commit itself never
@@ -186,26 +191,96 @@ fn preview(s: &str) -> String {
 
 /// Resolve the target `/workflows` directory, applying the opt-in gate.
 ///
-/// If `KOTO_WORKFLOWS_DIR` is set (the host handoff), self-publish it into this
-/// session's own context store -- so descendants discover it by the ancestor
-/// walk -- and use it. Otherwise resolve it by walking to the nearest published
-/// ancestor. `None` means no participation: write nothing.
+/// Resolution order:
+/// 1. `KOTO_WORKFLOWS_DIR` -- an explicit host handoff (e.g. a SessionStart
+///    hook). Self-published into this session's store so descendants discover
+///    it by the ancestor walk.
+/// 2. The nearest published ancestor (a location this session self-published on
+///    a prior commit, or an ancestor's). A cheap key probe; no config load.
+/// 3. The global opt-in `workflows.native`: self-discover the hosting Claude
+///    Code session's `/workflows` directory from the environment. Only reached
+///    on a participating session's first commit, before it self-publishes.
+///
+/// `None` means no participation: write nothing, default path untouched.
 fn resolve_target_dir(
     backend: &dyn SessionBackend,
     store: &dyn ContextStore,
     session_id: &str,
 ) -> Option<PathBuf> {
+    // 1. Explicit host handoff.
     if let Ok(env_dir) = std::env::var(WORKFLOWS_DIR_ENV) {
         let env_dir = env_dir.trim().to_string();
         if !env_dir.is_empty() {
-            if !discover::has_published_location(store, session_id) {
-                // Best-effort: self-publish so hierarchy descendants can discover it.
-                let _ = discover::publish_location(store, session_id, &env_dir);
-            }
+            self_publish_if_absent(store, session_id, &env_dir);
             return Some(PathBuf::from(env_dir));
         }
     }
-    discover::resolve_publish_location(backend, store, session_id)
+    // 2. Nearest published ancestor (self-published or hierarchy).
+    if let Some(dir) = discover::resolve_publish_location(backend, store, session_id) {
+        return Some(dir);
+    }
+    // 3. Config opt-in: self-discover from the Claude Code session environment.
+    if workflows_native_enabled() {
+        if let Some(dir) = resolve_from_claude_env() {
+            if let Some(s) = dir.to_str() {
+                self_publish_if_absent(store, session_id, s);
+            }
+            return Some(dir);
+        }
+    }
+    None
+}
+
+/// Publish `dir` as `session_id`'s location if it has not already published one
+/// (so descendants can discover it by the ancestor walk). Best-effort.
+fn self_publish_if_absent(store: &dyn ContextStore, session_id: &str, dir: &str) {
+    if !discover::has_published_location(store, session_id) {
+        let _ = discover::publish_location(store, session_id, dir);
+    }
+}
+
+/// Whether the `workflows.native` global opt-in is enabled. Best-effort: any
+/// config-load failure reads as disabled, so koto's default path is untouched.
+fn workflows_native_enabled() -> bool {
+    crate::config::resolve::load_config()
+        .map(|c| c.workflows.native)
+        .unwrap_or(false)
+}
+
+/// Derive the hosting Claude Code session's `/workflows` directory from the
+/// environment, with no SessionStart hook.
+///
+/// Claude Code exposes the viewing session's id to every subprocess as
+/// [`CLAUDE_SESSION_ID_ENV`] and renders `<projectDir>/<sessionId>/workflows/*.json`,
+/// where `<projectDir>` is the directory holding the session transcript
+/// `<sessionId>.jsonl` under `~/.claude/projects/`. Returns `None` when the env
+/// var is unset/empty or no matching transcript exists (e.g. a fully headless
+/// run) -- in which case nothing renders and the dashboard stays the surface.
+fn resolve_from_claude_env() -> Option<PathBuf> {
+    let session_id = std::env::var(CLAUDE_SESSION_ID_ENV).ok()?;
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        return None;
+    }
+    let home = std::env::var_os("HOME")?;
+    let projects = Path::new(&home).join(".claude").join("projects");
+    let project_dir = find_session_project_dir(&projects, session_id)?;
+    Some(project_dir.join(session_id).join("workflows"))
+}
+
+/// Find the project directory under `projects` that holds `<session_id>.jsonl`.
+/// The workflows directory is keyed to the session's project (where its
+/// transcript lives), not the koto process cwd, so the transcript's location is
+/// the authority. Returns the first match, or `None`.
+fn find_session_project_dir(projects: &Path, session_id: &str) -> Option<PathBuf> {
+    let transcript = format!("{session_id}.jsonl");
+    for entry in std::fs::read_dir(projects).ok()?.flatten() {
+        let dir = entry.path();
+        if dir.join(&transcript).is_file() {
+            return Some(dir);
+        }
+    }
+    None
 }
 
 /// A stable `startTime`: reuse the value already on disk (so the entry's start
@@ -605,5 +680,40 @@ mod tests {
         transition(&backend, "solo", "building");
 
         assert!(nested.join(workflow_filename("solo-uuid")).exists());
+    }
+
+    #[test]
+    fn find_session_project_dir_matches_transcript_owner() {
+        let projects = TempDir::new().unwrap();
+        let sid = "abc-123";
+        // Two encoded project dirs exist for the session id (e.g. cwd changed),
+        // but only one holds the `<sid>.jsonl` transcript.
+        let owner = projects.path().join("-home-user-proj");
+        let other = projects.path().join("-home-user-proj-sub");
+        std::fs::create_dir_all(&owner).unwrap();
+        std::fs::create_dir_all(&other).unwrap();
+        std::fs::write(owner.join(format!("{sid}.jsonl")), b"{}").unwrap();
+        // The `other` dir has a same-named directory but no transcript file.
+        std::fs::create_dir_all(other.join(sid)).unwrap();
+
+        let got = find_session_project_dir(projects.path(), sid);
+        assert_eq!(got, Some(owner));
+    }
+
+    #[test]
+    fn find_session_project_dir_none_without_transcript() {
+        let projects = TempDir::new().unwrap();
+        std::fs::create_dir_all(projects.path().join("-home-user-proj")).unwrap();
+        assert_eq!(
+            find_session_project_dir(projects.path(), "missing-sid"),
+            None
+        );
+    }
+
+    #[test]
+    fn find_session_project_dir_none_when_projects_absent() {
+        let tmp = TempDir::new().unwrap();
+        let absent = tmp.path().join("no-such-projects");
+        assert_eq!(find_session_project_dir(&absent, "any"), None);
     }
 }


### PR DESCRIPTION
Adds a global config opt-in for native `/workflows` rendering and lets a koto
session self-discover its target directory from the environment, so rendering no
longer requires the `koto-skills` `SessionStart` hook or plugin.

`koto config set workflows.native true --user` is the one-time opt-in. A koto
session driven inside a Claude Code session then reads `CLAUDE_CODE_SESSION_ID`
(which Claude Code sets in every subprocess), locates its transcript under
`~/.claude/projects/` to resolve the project dir, and writes into
`<projectDir>/<sessionId>/workflows`.

Resolution order in `resolve_target_dir`: `KOTO_WORKFLOWS_DIR` (explicit host
handoff) -> nearest published ancestor -> config-gated env self-discovery.
Config is loaded only on a session's cold path, before it self-publishes.
Default stays off; the `KOTO_WORKFLOWS_DIR` handoff remains a fallback.

Changes:

- `src/config/mod.rs`: new `[workflows]` table with `native: bool`, wired
  through get/set/unset/list with bool parsing.
- `src/config/resolve.rs`: presence-tracked merge so a layer with the key absent
  can't clobber one that set it.
- `src/workflows_surface/materialize.rs`: env self-discovery plus the transcript
  lookup, gated on the flag.
- docs: the verification guide leads with the config opt-in; the CLI config
  reference and the koto-user command reference list the new key.

---

## Verification

- `cargo test -- --test-threads=1`: **1253 passed, 0 failed**. New tests cover
  config get/set/unset and bool rejection, the presence-gated merge, and the
  transcript lookup (two-project disambiguation, no-transcript, and missing-dir
  cases).
- `cargo fmt --check` clean; the changed code is clippy-clean.
- Behavior confirmed against a live Claude Code TUI: a file written to the
  `CLAUDE_CODE_SESSION_ID`-derived directory renders in `/workflows` with full
  phase detail, with no hook or plugin involved.

## Notes

- The project-dir derivation relies on Claude Code's
  `~/.claude/projects/*/<id>.jsonl` transcript layout — undocumented and
  version-coupled (the same class of coupling the rest of this surface accepts).
  It fails closed: no match, nothing renders.
- One factual key was added to the koto-user command reference
  (`workflows.native` in the valid-keys list); no behavioral skill change, so
  evals were not re-run.
- Possible follow-up: how env self-discovery interacts with hierarchy rendering
  — a session and its in-process descendants share `CLAUDE_CODE_SESSION_ID`,
  which may simplify the nearest-published-ancestor walk.

## Checklist

- [x] No `EventPayload` variants or `StateFileHeader` fields were added, removed,
      or renamed, so `docs/reference/session-feed.md` needs no update.
