### PR TITLE
feat(workflows): default native /workflows rendering to on

### DIFF
--- a/docs/designs/current/DESIGN-native-workflows-render.md
+++ b/docs/designs/current/DESIGN-native-workflows-render.md
@@ -168,6 +168,21 @@ walking to this ancestor's published key -- so the same mechanism serves the
 single session and a future hierarchy's tree, and the opt-in stays "presence of a published
 location," not config.
 
+**Amended after ship.** Two follow-on changes evolved the enable model beyond this
+original design:
+
+- **Config-based enable + environment self-discovery.** koto can now resolve the target
+  directory itself from `CLAUDE_CODE_SESSION_ID` (which Claude Code sets in every
+  subprocess) by locating the session transcript under `~/.claude/projects/`, so native
+  rendering no longer requires the `koto-skills` SessionStart hook or plugin. The
+  `KOTO_WORKFLOWS_DIR` handoff and the published-location walk both remain, as the first
+  two steps of the resolution order.
+- **On by default.** A `workflows.native` config flag gates env self-discovery, and its
+  default is `true`. Rendering is therefore on by default for any koto session running
+  inside a Claude Code session; a fully headless run still renders nothing, and an
+  operator opts out with `workflows.native = false`. The original "opt-in is presence of a
+  published location, not config" framing is superseded by this default-on config gate.
+
 - *Rejected: the hook shells out `koto context add <koto-session> ...`.* The
   most direct "publish into the context store" phrasing, but it presumes the
   hook knows the koto session id, which does not exist at `SessionStart`. It also

--- a/docs/guides/cli-usage.md
+++ b/docs/guides/cli-usage.md
@@ -599,11 +599,11 @@ koto config list --json
 | `session.cloud.region` | AWS region | -- | yes |
 | `session.cloud.access_key` | Access key ID | -- | no |
 | `session.cloud.secret_key` | Secret access key | -- | no |
-| `workflows.native` | `true`, `false` | `false` | yes |
+| `workflows.native` | `true`, `false` | `true` | yes |
 
 Credential keys (`access_key`, `secret_key`) can also be provided through environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. Environment variables take precedence over config file values.
 
-`workflows.native` opts in to rendering koto sessions in Claude Code's `/workflows` screen (see [native-workflows-verification.md](native-workflows-verification.md)); a participating session self-discovers its target directory from `CLAUDE_CODE_SESSION_ID`.
+`workflows.native` controls rendering koto sessions in Claude Code's `/workflows` screen (see [native-workflows-verification.md](native-workflows-verification.md)); it is on by default and a participating session self-discovers its target directory from `CLAUDE_CODE_SESSION_ID`. Set it to `false` to opt out. A fully headless run (no Claude Code environment) renders nothing regardless.
 
 #### Example: local-only config (default)
 

--- a/docs/guides/native-workflows-verification.md
+++ b/docs/guides/native-workflows-verification.md
@@ -23,8 +23,8 @@ Expected output ends with
 exercises everything koto owns:
 
 - **The initial render** — single-session render with the current state, update on
-  advance, done-on-completion, the opt-in no-write path (default path
-  untouched), and the atomic `koto-<uuid>.json` filename.
+  advance, done-on-completion, the no-write path when no target resolves (default
+  path untouched), and the atomic `koto-<uuid>.json` filename.
 - **The phase-detail enrichment** — the phases render in order with the active one marked, the
   active phase's directive is legible, a completed phase shows its gate outcome,
   and a session whose gate did not pass renders as `blocked` (not running, not
@@ -47,20 +47,20 @@ for its version/fixture guard over the undocumented surface.
 This confirms the one thing the automated check cannot: that Claude Code renders
 the emitted file.
 
-1. **Enable rendering (once).** Opt in with a config flag:
+1. **Rendering is on by default.** A koto session driven inside a Claude Code
+   session self-discovers that session's workflows directory from the
+   `CLAUDE_CODE_SESSION_ID` environment variable Claude Code sets in every
+   subprocess — no plugin, hook, or manual export required. A fully headless run
+   (no Claude Code environment) still renders nothing.
+
+   To opt out, set the flag to false:
 
    ```bash
-   koto config set workflows.native true --user
+   koto config set workflows.native false --user
    ```
 
-   With this set, a koto session driven inside a Claude Code session
-   self-discovers that session's workflows directory from the
-   `CLAUDE_CODE_SESSION_ID` environment variable Claude Code sets in every
-   subprocess — no plugin, hook, or manual export required. It stays off by
-   default, so koto's normal path is untouched until you opt in.
-
-   *Alternative (explicit handoff):* instead of the config flag, export the
-   directory directly — useful for a headless host or a non-standard layout:
+   *Alternative (explicit handoff):* to point koto at a specific directory —
+   useful for a non-standard layout — export it directly:
 
    ```bash
    export KOTO_WORKFLOWS_DIR="<projectDir>/<sessionId>/workflows"
@@ -89,9 +89,9 @@ the emitted file.
 6. **Complete and reopen.** Drive the session to its terminal state, then reopen
    `/workflows` — the entry reads *done* (completed), not a stuck *running*.
 
-7. **Negative check.** With rendering disabled (`workflows.native` unset and no
-   `KOTO_WORKFLOWS_DIR`), run a koto session and confirm `/workflows` is
-   unaffected and no `koto-*.json` is written.
+7. **Negative check.** With rendering opted out (`koto config set
+   workflows.native false`) and no `KOTO_WORKFLOWS_DIR`, run a koto session and
+   confirm `/workflows` is unaffected and no `koto-*.json` is written.
 
 ## Notes
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,17 +16,30 @@ pub struct KotoConfig {
 
 /// Native Claude Code `/workflows` rendering configuration.
 ///
-/// `native` is the global opt-in for rendering koto sessions in Claude Code's
-/// `/workflows` screen. When true, a session driven inside a Claude Code
-/// session self-discovers that session's workflows directory from the
+/// `native` controls whether koto sessions render in Claude Code's `/workflows`
+/// screen. When true, a session driven inside a Claude Code session
+/// self-discovers that session's workflows directory from the
 /// `CLAUDE_CODE_SESSION_ID` environment variable and renders into it -- no
-/// SessionStart hook or plugin required. Defaults to false, so koto's default
-/// path is untouched until an operator opts in (`koto config set
-/// workflows.native true --user`).
-#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
+/// SessionStart hook or plugin required. **Defaults to true (on).** A session
+/// with no discoverable Claude Code environment (fully headless) still renders
+/// nothing, so the default path is untouched there. To opt out, set
+/// `koto config set workflows.native false --user`.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct WorkflowsConfig {
-    #[serde(default)]
+    #[serde(default = "default_native")]
     pub native: bool,
+}
+
+impl Default for WorkflowsConfig {
+    fn default() -> Self {
+        Self {
+            native: default_native(),
+        }
+    }
+}
+
+fn default_native() -> bool {
+    true
 }
 
 /// Request-store (coordinator/operator) configuration.
@@ -649,12 +662,12 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_workflows_native_defaults_false() {
+    fn test_workflows_native_defaults_true() {
         let config = KotoConfig::default();
-        assert!(!config.workflows.native);
+        assert!(config.workflows.native);
         assert_eq!(
             get_value(&config, "workflows.native"),
-            Some("false".to_string())
+            Some("true".to_string())
         );
     }
 
@@ -672,10 +685,23 @@ mod tests {
 
     #[test]
     fn test_workflows_native_partial_toml_uses_defaults() {
-        // A config that only sets request_store leaves workflows.native false.
+        // A config that only sets request_store leaves workflows.native at its
+        // default (on).
         let toml_str = "[request_store]\nredelegation_cap = 5\n";
         let cfg: KotoConfig = toml::from_str(toml_str).unwrap();
+        assert!(cfg.workflows.native);
+    }
+
+    #[test]
+    fn test_workflows_native_explicit_optout_parses() {
+        // Opting out is an explicit `native = false`.
+        let toml_str = "[workflows]\nnative = false\n";
+        let cfg: KotoConfig = toml::from_str(toml_str).unwrap();
         assert!(!cfg.workflows.native);
+        assert_eq!(
+            get_value(&cfg, "workflows.native"),
+            Some("false".to_string())
+        );
     }
 
     #[test]

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -441,36 +441,52 @@ mod tests {
         fs::write(&path, "[session]\nbackend = \"local\"\n").unwrap();
 
         let loaded = load_config_file(&path).unwrap();
-        assert!(!loaded.config.workflows.native);
+        // Absent from the file: not tracked for merge, and left at the default (on).
         assert!(!loaded.workflows_native_present);
+        assert!(loaded.config.workflows.native);
+    }
+
+    #[test]
+    fn test_workflows_native_explicit_optout_tracked() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        fs::write(&path, "[workflows]\nnative = false\n").unwrap();
+
+        let loaded = load_config_file(&path).unwrap();
+        assert!(loaded.workflows_native_present);
+        assert!(!loaded.config.workflows.native);
     }
 
     #[test]
     fn test_merge_applies_workflows_native_only_when_present() {
-        // present=true flips the base on.
+        // An explicit opt-out (present, native=false) overrides the default-on base.
         let mut base = KotoConfig::default();
-        let mut on = KotoConfig::default();
-        on.workflows.native = true;
-        let overlay = LoadedConfig {
-            config: on.clone(),
+        assert!(base.workflows.native, "default is on");
+        let mut off = KotoConfig::default();
+        off.workflows.native = false;
+        let optout = LoadedConfig {
+            config: off,
             request_store_keys: vec![],
             request_store_has_recursion: false,
             workflows_native_present: true,
         };
-        merge_config(&mut base, &overlay);
-        assert!(base.workflows.native);
+        merge_config(&mut base, &optout);
+        assert!(
+            !base.workflows.native,
+            "explicit opt-out overrides the default"
+        );
 
-        // present=false must NOT overwrite an already-on base.
-        let mut base_on = KotoConfig::default();
-        base_on.workflows.native = true;
-        let overlay_absent = LoadedConfig {
+        // An absent key (not present in the layer) leaves the base untouched.
+        let mut base_off = KotoConfig::default();
+        base_off.workflows.native = false;
+        let absent = LoadedConfig {
             config: KotoConfig::default(),
             request_store_keys: vec![],
             request_store_has_recursion: false,
             workflows_native_present: false,
         };
-        merge_config(&mut base_on, &overlay_absent);
-        assert!(base_on.workflows.native, "absent key must not clobber");
+        merge_config(&mut base_off, &absent);
+        assert!(!base_off.workflows.native, "absent key must not clobber");
     }
 
     #[test]

--- a/src/workflows_surface/materialize.rs
+++ b/src/workflows_surface/materialize.rs
@@ -7,9 +7,12 @@
 //! individual commands. It is **best-effort**: it never fails the commit
 //! (mirroring the cloud backend's swallow-on-side-effect discipline).
 //!
-//! Opt-in is the presence of a published location (or the `KOTO_WORKFLOWS_DIR`
-//! host handoff). With neither, the function returns after a cheap probe,
-//! writing nothing -- koto's default path is untouched.
+//! Rendering is on by default (`workflows.native`, default true): a session
+//! writes when it can resolve a target directory -- a published location, the
+//! `KOTO_WORKFLOWS_DIR` host handoff, or self-discovery from the Claude Code
+//! session environment. When none resolves (fully headless) or the operator has
+//! opted out (`workflows.native = false`), the function returns after a cheap
+//! probe, writing nothing -- koto's default path is untouched there.
 
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -31,7 +34,7 @@ const PREVIEW_MAX: usize = 240;
 pub const WORKFLOWS_DIR_ENV: &str = "KOTO_WORKFLOWS_DIR";
 
 /// Environment variable Claude Code sets to the viewing session's id in every
-/// subprocess. Under the `workflows.native` opt-in, koto self-discovers the
+/// subprocess. Under `workflows.native` (default on), koto self-discovers the
 /// session's `/workflows` directory from it -- no `SessionStart` hook required.
 const CLAUDE_SESSION_ID_ENV: &str = "CLAUDE_CODE_SESSION_ID";
 
@@ -55,7 +58,7 @@ fn try_materialize(
     store: &dyn ContextStore,
     session_id: &str,
 ) -> anyhow::Result<()> {
-    // Opt-in gate: resolve the target directory, or return writing nothing.
+    // Render gate: resolve the target directory, or return writing nothing.
     let dir = match resolve_target_dir(backend, store, session_id) {
         Some(d) => d,
         None => return Ok(()),
@@ -189,7 +192,7 @@ fn preview(s: &str) -> String {
     out
 }
 
-/// Resolve the target `/workflows` directory, applying the opt-in gate.
+/// Resolve the target `/workflows` directory, applying the render gate.
 ///
 /// Resolution order:
 /// 1. `KOTO_WORKFLOWS_DIR` -- an explicit host handoff (e.g. a SessionStart
@@ -197,11 +200,13 @@ fn preview(s: &str) -> String {
 ///    it by the ancestor walk.
 /// 2. The nearest published ancestor (a location this session self-published on
 ///    a prior commit, or an ancestor's). A cheap key probe; no config load.
-/// 3. The global opt-in `workflows.native`: self-discover the hosting Claude
-///    Code session's `/workflows` directory from the environment. Only reached
-///    on a participating session's first commit, before it self-publishes.
+/// 3. `workflows.native` (default on): self-discover the hosting Claude Code
+///    session's `/workflows` directory from the environment. Only reached on a
+///    participating session's first commit, before it self-publishes; skipped
+///    when the operator has opted out (`workflows.native = false`).
 ///
-/// `None` means no participation: write nothing, default path untouched.
+/// `None` means no target resolved: write nothing, default path untouched
+/// (fully headless, or opted out).
 fn resolve_target_dir(
     backend: &dyn SessionBackend,
     store: &dyn ContextStore,
@@ -219,7 +224,8 @@ fn resolve_target_dir(
     if let Some(dir) = discover::resolve_publish_location(backend, store, session_id) {
         return Some(dir);
     }
-    // 3. Config opt-in: self-discover from the Claude Code session environment.
+    // 3. Config gate (on by default): self-discover from the Claude Code
+    //    session environment unless the operator opted out.
     if workflows_native_enabled() {
         if let Some(dir) = resolve_from_claude_env() {
             if let Some(s) = dir.to_str() {
@@ -239,8 +245,10 @@ fn self_publish_if_absent(store: &dyn ContextStore, session_id: &str, dir: &str)
     }
 }
 
-/// Whether the `workflows.native` global opt-in is enabled. Best-effort: any
-/// config-load failure reads as disabled, so koto's default path is untouched.
+/// Whether `workflows.native` is enabled (default true). Best-effort: a
+/// config-load failure (a malformed config file) reads as disabled -- the
+/// conservative side for a directory koto does not own. Absence of any config
+/// file is not a failure; it resolves to the default (on).
 fn workflows_native_enabled() -> bool {
     crate::config::resolve::load_config()
         .map(|c| c.workflows.native)
@@ -596,6 +604,31 @@ mod tests {
         serde_json::from_slice(&bytes).ok()
     }
 
+    /// RAII guard that overrides `$HOME` for the duration of a test and restores
+    /// it on drop, so the config load and env self-discovery resolve against a
+    /// controlled directory. Env mutation is process-global; CI runs
+    /// `--test-threads=1` (see `.github/workflows/validate.yml`).
+    struct HomeGuard {
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl HomeGuard {
+        fn set(path: &Path) -> Self {
+            let prev = std::env::var_os("HOME");
+            std::env::set_var("HOME", path);
+            HomeGuard { prev }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
     #[test]
     fn ac1_file_appears_with_current_state() {
         let base = TempDir::new().unwrap();
@@ -634,19 +667,44 @@ mod tests {
     }
 
     #[test]
-    fn ac4_no_write_without_published_location() {
+    fn ac4_no_write_when_headless_and_unpublished() {
         let base = TempDir::new().unwrap();
         let wf = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        // Rendering is on by default, but point HOME at an empty directory so
+        // env self-discovery finds no session transcript. With no published
+        // location and no KOTO_WORKFLOWS_DIR either, the fully-headless case
+        // writes nothing -- koto's default path is untouched.
+        let _home = HomeGuard::set(home.path());
         let backend = LocalBackend::with_base_dir(base.path().to_path_buf());
         init_session(&backend, "solo");
-        // No publish_location call, and KOTO_WORKFLOWS_DIR is unset in this test.
 
         transition(&backend, "solo", "building");
 
-        // Nothing materialized; the /workflows dir is untouched (empty).
         assert!(read_file(wf.path(), "solo-uuid").is_none());
         let entries: Vec<_> = std::fs::read_dir(wf.path()).unwrap().collect();
         assert!(entries.is_empty(), "no koto-*.json written");
+    }
+
+    #[test]
+    fn native_gate_default_on_and_respects_explicit_optout() {
+        let home = TempDir::new().unwrap();
+        let _home = HomeGuard::set(home.path());
+        // No config file: the gate resolves to the default (on).
+        assert!(workflows_native_enabled(), "default is on");
+
+        // An explicit opt-out in user config turns the gate off.
+        let koto_dir = home.path().join(".koto");
+        std::fs::create_dir_all(&koto_dir).unwrap();
+        std::fs::write(
+            koto_dir.join("config.toml"),
+            "[workflows]\nnative = false\n",
+        )
+        .unwrap();
+        assert!(
+            !workflows_native_enabled(),
+            "explicit opt-out disables the gate"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Flip the `workflows.native` default from false to true, so a koto session driven inside a Claude Code session renders in `/workflows` by default via environment self-discovery from `CLAUDE_CODE_SESSION_ID`. A fully headless run (no Claude Code environment) still renders nothing, and an operator opts out with `koto config set workflows.native false`.

`WorkflowsConfig` gains a custom `Default` (native = true) and a serde default, so an absent `[workflows]` table resolves to on while the presence-tracked merge still lets an explicit `native = false` at any config layer override it. The config gate's conservative-on-parse-error behavior is unchanged: a malformed config file reads as disabled.

Reframe the render-gate tests for default-on: the former "no write without a published location" case becomes a headless no-write assertion (HOME pointed at an empty directory so env self-discovery finds no transcript), plus a new test covering the explicit `workflows.native = false` opt-out. Update the verification guide and the CLI config reference, and amend `DESIGN-native-workflows-render` to record the config-enable and env-self-discovery evolution and the default flip.

---

## Verification

- `cargo test -- --test-threads=1`: **1256 passed, 0 failed**. New/updated coverage: default-on resolution, presence-gated merge with an explicit opt-out, the headless no-write path, and the gate's opt-out short-circuit.
- `cargo fmt --check` clean; the changed code is clippy-clean.

## Notes for reviewers

- **This changes default behavior.** Any koto session run inside a Claude Code session now renders into that session's `/workflows` directory unless the operator sets `workflows.native = false`. It was previously off by default.
- **Known trade-offs at default-on** (tracked, not resolved here): koto entries accumulate in a directory koto does not own (no retention policy yet), and an ungracefully-killed session shows as a lingering "running" entry until cleared. Both were acceptable while the feature was off by default; turning it on widens who encounters them.
- **HOME-guard tests** mutate a process-global env var and rely on CI's `--test-threads=1` (matching the existing config-resolve test pattern).
