### PR TITLE
fix(engine): default schema_version so old state files stay readable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "koto"
-version = "0.10.1-dev"
+version = "0.11.3-dev"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/src/engine/persistence.rs
+++ b/src/engine/persistence.rs
@@ -1042,6 +1042,52 @@ mod tests {
         );
     }
 
+    #[test]
+    fn header_missing_schema_version_defaults_to_1() {
+        // Older sessions were written before `schema_version` existed in
+        // the header. Such a header must parse (as version 1) rather than
+        // fail with "missing field schema_version", so discovery stops
+        // warning about it and the session stays readable.
+        let dir = TempDir::new().unwrap();
+        let header = make_header();
+        let mut header_json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&header).unwrap()).unwrap();
+        header_json
+            .as_object_mut()
+            .unwrap()
+            .remove("schema_version");
+        assert!(
+            header_json.get("schema_version").is_none(),
+            "test setup: schema_version should be absent"
+        );
+
+        let path = dir.path().join("koto-legacy.state.jsonl");
+        let mut content = serde_json::to_string(&header_json).unwrap();
+        content.push('\n');
+        content.push_str(
+            &serde_json::to_string(&make_event(
+                1,
+                EventPayload::WorkflowInitialized {
+                    template_path: "/cache/abc.json".to_string(),
+                    variables: HashMap::new(),
+                    spawn_entry: None,
+                },
+            ))
+            .unwrap(),
+        );
+        content.push('\n');
+        std::fs::write(&path, &content).unwrap();
+
+        let parsed = read_header(&path).expect("header missing schema_version must parse");
+        assert_eq!(parsed.schema_version, 1);
+
+        // The full read path recovers too, not just the header.
+        let (parsed_header, events) =
+            read_events(&path).expect("read_events must recover legacy header");
+        assert_eq!(parsed_header.schema_version, 1);
+        assert_eq!(events.len(), 1);
+    }
+
     // -----------------------------------------------------------------------
     // Header parsing
     // -----------------------------------------------------------------------

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -198,6 +198,23 @@ impl AsRef<str> for ValidatedCoordId {
 /// Additive optional fields do NOT require a bump.
 pub const CURRENT_SCHEMA_VERSION: u32 = 1;
 
+/// Schema version assumed for a header line that omits `schema_version`.
+///
+/// The field has been written into every header since the event-log
+/// format was introduced (schema version 1), so a header lacking it was
+/// written before the field existed and is, by definition, version 1.
+///
+/// This is a fixed literal, deliberately NOT `CURRENT_SCHEMA_VERSION`:
+/// if the current version is later bumped, a header that omits the field
+/// must still read as 1 rather than silently adopting the newest
+/// version. Recovering the field on read (rather than rejecting the
+/// file) keeps sessions from older koto builds readable instead of
+/// surfacing them as `state file corrupted: missing field
+/// schema_version` during discovery.
+fn default_schema_version() -> u32 {
+    1
+}
+
 /// Header line written as the first line of a state file.
 ///
 /// Contains metadata about the workflow log. Has no `seq` field -- it is
@@ -205,6 +222,11 @@ pub const CURRENT_SCHEMA_VERSION: u32 = 1;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StateFileHeader {
     /// Format version; currently `1`.
+    ///
+    /// Defaults to `1` when absent so state files written before the
+    /// field existed remain readable rather than failing to parse with
+    /// `missing field schema_version`. See `default_schema_version`.
+    #[serde(default = "default_schema_version")]
     pub schema_version: u32,
 
     /// Workflow name; must match the state filename.

--- a/tests/diagnostics_streams.rs
+++ b/tests/diagnostics_streams.rs
@@ -1,0 +1,58 @@
+//! Issue 185: migration/discovery diagnostics must land on stderr so an
+//! automated caller can read a command's result from stdout without
+//! filtering. This guards the stream routing against a regression where
+//! an `eprintln!` diagnostic is changed to `println!`.
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+
+/// Build a `koto` command rooted at a throwaway HOME so the real local
+/// backend (and its old-layout migration) runs against a controlled
+/// `~/.koto/sessions/`. `KOTO_SESSIONS_BASE` is deliberately NOT set:
+/// that override bypasses the migration path this test exercises.
+fn koto_at_home(home: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("koto").unwrap();
+    cmd.env("HOME", home);
+    cmd.env_remove("KOTO_SESSIONS_BASE");
+    cmd
+}
+
+#[test]
+fn migration_skipped_notice_goes_to_stderr_not_stdout() {
+    let home = tempfile::tempdir().unwrap();
+    let sessions = home.path().join(".koto").join("sessions");
+
+    // Old per-repo layout: `sessions/<16-hex>/<session>/`. Placing a
+    // session there whose name already exists at the flat level forces
+    // the "migration skipped: session already exists" notice.
+    let repo_id = "0123456789abcdef";
+    let session = "collide-session";
+    let old = sessions.join(repo_id).join(session);
+    fs::create_dir_all(&old).unwrap();
+    fs::write(old.join("koto-collide-session.state.jsonl"), "{}\n").unwrap();
+    fs::create_dir_all(sessions.join(session)).unwrap();
+
+    let output = koto_at_home(home.path())
+        .args(["session", "list"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    // The diagnostic must be on stderr, never on stdout.
+    assert!(
+        stderr.contains("migration skipped"),
+        "expected migration notice on stderr, got stderr: {stderr:?}"
+    );
+    assert!(
+        !stdout.contains("migration skipped"),
+        "migration notice leaked onto stdout: {stdout:?}"
+    );
+
+    // stdout must carry only the command result: a single JSON value.
+    let trimmed = stdout.trim();
+    serde_json::from_str::<serde_json::Value>(trimmed)
+        .unwrap_or_else(|e| panic!("stdout must be a single JSON value, got {stdout:?}: {e}"));
+}

--- a/tests/discovery_scan.rs
+++ b/tests/discovery_scan.rs
@@ -685,6 +685,40 @@ fn scan_returns_empty_when_sessions_dir_missing() {
     assert!(out.is_empty());
 }
 
+// ----- Regression: legacy header missing schema_version -------------------
+
+/// Rewrite a state file's header line to drop the `schema_version` key,
+/// simulating a session written before the field existed.
+fn strip_schema_version(path: &Path) {
+    let content = fs::read_to_string(path).unwrap();
+    let mut lines: Vec<String> = content.lines().map(|l| l.to_string()).collect();
+    let mut header: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+    header.as_object_mut().unwrap().remove("schema_version");
+    assert!(header.get("schema_version").is_none());
+    lines[0] = serde_json::to_string(&header).unwrap();
+    fs::write(path, format!("{}\n", lines.join("\n"))).unwrap();
+}
+
+#[test]
+fn scan_discovers_child_whose_header_omits_schema_version() {
+    // Issue 185: a child session written before `schema_version` existed
+    // used to fail header parsing during discovery ("state file
+    // corrupted: missing field schema_version") and be skipped with a
+    // stderr warning. It must now be admitted as a normal candidate.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let path = write_session(
+        root,
+        &make_unassigned_child_header("legacy-child"),
+        now_micros() - 100,
+    );
+    strip_schema_version(&path);
+
+    let out = scan(root, &coord(), &RequestStoreConfig::default()).unwrap();
+    assert_eq!(out.len(), 1, "legacy-header child must be discovered");
+    assert_eq!(out[0].child_session_id, "legacy-child");
+}
+
 // Silence the UnassignedChild-rebind warning under -D warnings; this is
 // here so the type import is exercised even if future refactors stop
 // using it directly.

--- a/tests/header_serde_round_trip.rs
+++ b/tests/header_serde_round_trip.rs
@@ -94,6 +94,22 @@ fn pre_request_store_fixture_header_deserializes_with_defaults() {
 }
 
 #[test]
+fn header_without_schema_version_defaults_to_1() {
+    // Sessions written before `schema_version` was added to the header
+    // omit the key entirely. Such a header must deserialize (as version
+    // 1) rather than failing with "missing field schema_version", so
+    // discovery stops warning about it and the session stays readable.
+    let legacy_json = r#"{
+        "workflow": "old-wf",
+        "template_hash": "abc",
+        "created_at": "2026-01-01T00:00:00Z"
+    }"#;
+    let parsed: StateFileHeader =
+        serde_json::from_str(legacy_json).expect("header missing schema_version must deserialize");
+    assert_eq!(parsed.schema_version, 1);
+}
+
+#[test]
 fn needs_agent_alone_deserializes() {
     // CLI-layer companion validation is owned by Issue 4; the type
     // layer must accept `needs_agent = true` even without role /


### PR DESCRIPTION
Sessions written before the state-file header carried a `schema_version`
field fail to parse today with `state file corrupted: failed to parse
header: missing field schema_version`. Discovery warns and skips them on
every scan, and read-side commands (`status`, `next`, `list`) report
them as corrupted.

This gives `schema_version` a serde default of 1. A header lacking the
field predates its introduction, which shipped alongside schema version
1, so it is version 1 by definition. The default is a fixed literal
rather than `CURRENT_SCHEMA_VERSION`, so a future version bump cannot
make a field-less header silently adopt the newest version. The other
required header keys keep no default, so a genuinely foreign or corrupt
first line still fails to parse -- only well-formed event-log headers
missing exactly the version field are recovered.

The migration ("session already exists") and discovery ("skipping ...
during discovery") diagnostics already route to stderr via `eprintln!`,
so an automated caller reads a command's JSON result from stdout without
filtering. An audit of every `println!` in the command paths confirmed
only intended command results, the version string, and the interactive
`workspace prune` confirmation reach stdout. A new stream test locks the
routing in against a future `eprintln!`-to-`println!` regression.

---

Closes #185.

## What changed

- `schema_version` gains `#[serde(default = "default_schema_version")]`,
  defaulting to a fixed `1`. Old headers now parse instead of failing.
- No new CLI flags, subcommands, or response fields; no koto-skills
  surface is affected (checked per the repo's skill-maintenance rule).

## Testing

- `header_without_schema_version_defaults_to_1` (type-level) and
  `header_missing_schema_version_defaults_to_1` (through
  `read_header` / `read_events`): a header omitting the field reads as
  version 1 and the full event stream recovers.
- `scan_discovers_child_whose_header_omits_schema_version`: discovery
  admits such a session as a normal candidate instead of skipping it
  with a stderr warning.
- `migration_skipped_notice_goes_to_stderr_not_stdout`: the migration
  notice lands on stderr while stdout carries only a single JSON value.
- `cargo test` (1257 unit + integration), `cargo fmt --check`, and
  `cargo clippy -- -D warnings` all pass.

## Notes for the reviewer

The two named diagnostics were already on stderr at `main`, so stdout
was clean for them before this PR; the change here removes the deeper
cause of the recurring discovery noise (unreadable legacy headers) and
adds a regression test to keep the routing correct. The `Cargo.lock`
change is an incidental sync of the stale `koto` version to the manifest
(`0.10.1-dev` -> `0.11.3-dev`) that any build on `main` produces.
