### PR TITLE
ci: adopt shirabe's reusable lifecycle-check workflow

### DIFF
--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -1,0 +1,32 @@
+name: Lifecycle Check
+
+# Adopts shirabe's reusable chain-lifecycle gate. The reusable workflow builds
+# the shirabe binary at the referenced ref and runs `shirabe validate
+# --lifecycle .` against the whole tree: DRAFT PRs run in draft posture (mid-
+# chain states pass), READY PRs run in ready posture and require single-pr
+# chains to be at their terminal state (PLAN deleted, BRIEF/PRD Done, DESIGN
+# Current). See shirabe's docs/briefs/BRIEF-lifecycle-draft-ready-discipline.md
+# for the DRAFT-vs-READY discipline this enforces.
+#
+# Pinned to @main to match this repo's other shirabe reusable-workflow
+# adoption (validate-docs.yml, validate-pr-body.yml), so the gate always runs
+# the current engine without per-release pin bumps.
+#
+# `types:` includes ready_for_review and converted_to_draft so the strictness
+# branch is re-evaluated on every draft-to-ready and ready-to-draft
+# transition, mirroring shirabe's own self-caller (validate-lifecycle.yml).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+
+# Granted on the caller so the called reusable workflow's `permissions` block
+# (contents: read + pull-requests: read) is a subset of what this caller has.
+# A reusable workflow cannot request a permission the caller lacks.
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lifecycle:
+    uses: tsukumogami/shirabe/.github/workflows/lifecycle.yml@main

--- a/docs/designs/current/DESIGN-auto-advance-transitions.md
+++ b/docs/designs/current/DESIGN-auto-advance-transitions.md
@@ -1,5 +1,5 @@
 ---
-status: Implemented
+status: Current
 problem: |
   Plan-backed orchestrator workflows contain states whose evidence submissions are
   fully deterministic given the current context -- yet agents must drive each state
@@ -31,7 +31,7 @@ rationale: |
 
 ## Status
 
-Implemented
+Current
 
 ## Context and Problem Statement
 

--- a/docs/designs/current/DESIGN-default-action-execution.md
+++ b/docs/designs/current/DESIGN-default-action-execution.md
@@ -3,7 +3,7 @@ status: Current
 spawned_from:
   issue: 71
   repo: tsukumogami/koto
-  parent_design: docs/designs/DESIGN-shirabe-work-on-template.md
+  parent_design: docs/designs/current/DESIGN-shirabe-work-on-template.md
 problem: |
   koto's engine can verify outcomes via gates but can't execute deterministic work
   itself. Five states in the work-on template need default actions (run a script,

--- a/docs/designs/current/DESIGN-gate-backward-compat.md
+++ b/docs/designs/current/DESIGN-gate-backward-compat.md
@@ -1,5 +1,5 @@
 ---
-status: Implemented
+status: Current
 upstream: docs/prds/PRD-gate-transition-contract.md
 problem: |
   Feature 1 preserved legacy gate behavior implicitly: when no `when` clause
@@ -28,7 +28,7 @@ rationale: |
 
 ## Status
 
-Implemented
+Current
 
 ## Upstream design reference
 

--- a/docs/designs/current/DESIGN-koto-ad-hoc-workflows.md
+++ b/docs/designs/current/DESIGN-koto-ad-hoc-workflows.md
@@ -1,5 +1,5 @@
 ---
-status: Planned
+status: Current
 problem: |
   koto can only run a workflow from a pre-authored, compiled template, so an
   agent facing a novel complex task cannot get koto's ordered, recoverable,
@@ -28,7 +28,7 @@ rationale: |
 
 ## Status
 
-Planned
+Current
 
 ## Context and Problem Statement
 

--- a/docs/designs/current/DESIGN-local-dashboard.md
+++ b/docs/designs/current/DESIGN-local-dashboard.md
@@ -1,5 +1,5 @@
 ---
-status: Implemented
+status: Current
 upstream: docs/prds/PRD-local-dashboard.md
 problem: |
   koto had no live visibility surface. The engine writes session state to JSONL
@@ -59,7 +59,7 @@ rationale: |
 
 ## Status
 
-Implemented
+Current
 
 > **Note:** Superseded in part by DESIGN-session-legibility (PR #166): the `--once` output now has 8 columns (adds `idle`, `liveness`) and the list is attention-ordered, not health-severity sorted.
 

--- a/docs/designs/current/DESIGN-mid-state-decision-capture.md
+++ b/docs/designs/current/DESIGN-mid-state-decision-capture.md
@@ -3,7 +3,7 @@ status: Current
 spawned_from:
   issue: 68
   repo: tsukumogami/koto
-  parent_design: docs/designs/DESIGN-shirabe-work-on-template.md
+  parent_design: docs/designs/current/DESIGN-shirabe-work-on-template.md
 problem: |
   During long-running judgment states like implementation and analysis, agents make
   non-obvious choices — assumptions about API behavior, tradeoff decisions, approach

--- a/docs/designs/current/DESIGN-shirabe-work-on-template.md
+++ b/docs/designs/current/DESIGN-shirabe-work-on-template.md
@@ -1,5 +1,5 @@
 ---
-status: Planned
+status: Current
 problem: |
   shirabe's /work-on workflow exists and works, but it runs entirely through agent
   instructions. koto's template engine can't yet express it as a template because the
@@ -37,7 +37,7 @@ rationale: |
 
 ## Status
 
-Planned
+Current
 
 ## Context and Problem Statement
 

--- a/docs/designs/current/DESIGN-template-variable-substitution.md
+++ b/docs/designs/current/DESIGN-template-variable-substitution.md
@@ -3,7 +3,7 @@ status: Current
 spawned_from:
   issue: 67
   repo: tsukumogami/koto
-  parent_design: docs/designs/DESIGN-shirabe-work-on-template.md
+  parent_design: docs/designs/current/DESIGN-shirabe-work-on-template.md
 problem: |
   koto's template engine declares variables (VariableDecl in src/template/types.rs)
   and carries a variables field in the WorkflowInitialized event, but neither is wired


### PR DESCRIPTION
Adds a caller workflow for shirabe's reusable `lifecycle.yml`, pinned to `@main` to match this repo's existing shirabe adoptions (`validate-docs.yml`, `validate-pr-body.yml`). Without it, a ready-for-review PR carrying a single-pr PLAN that hasn't reached its terminal state (PLAN deleted, DESIGN Current) gets no CI signal at all.

---

## Context

Part of a small pass across the org's public repos after finding tsuku had the same gap (tsukumogami/tsuku#2493): shirabe ships the reusable lifecycle gate, but only shirabe itself was calling it.

## Test plan

- CI on this PR itself exercises the new caller in draft posture.
